### PR TITLE
feat(server): Phase 2b — production worker pool, live delivery, retry & DLQ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,17 @@ DATABASE_URL=postgres://chorus:chorus@localhost:5432/chorus
 REDIS_URL=redis://127.0.0.1:6379
 HOST=0.0.0.0
 PORT=3000
+WORKER_CONCURRENCY=4
 
 # SMS Providers (configure at least one)
 # TELNYX_API_KEY=KEY_xxx
+# TELNYX_FROM=+1xxx
 # TWILIO_ACCOUNT_SID=ACxxx
 # TWILIO_AUTH_TOKEN=xxx
-# TWILIO_FROM_NUMBER=+1xxx
+# TWILIO_FROM=+1xxx
 # PLIVO_AUTH_ID=xxx
 # PLIVO_AUTH_TOKEN=xxx
-# PLIVO_FROM_NUMBER=+1xxx
+# PLIVO_FROM=+1xxx
 
 # Email Providers (configure at least one)
 # RESEND_API_KEY=re_xxx

--- a/crates/chorus-server/src/app.rs
+++ b/crates/chorus-server/src/app.rs
@@ -4,7 +4,8 @@ use sqlx::PgPool;
 use std::sync::Arc;
 
 use crate::db::postgres::PgRepository;
-use crate::db::{AccountRepository, ApiKeyRepository, MessageRepository};
+use crate::db::provider_config::PgProviderConfigRepository;
+use crate::db::{AccountRepository, ApiKeyRepository, MessageRepository, ProviderConfigRepository};
 use crate::routes;
 
 /// Shared application state accessible to all request handlers.
@@ -19,18 +20,22 @@ pub struct AppState {
     message_repo: Arc<dyn MessageRepository>,
     /// API key management repository.
     api_key_repo: Arc<dyn ApiKeyRepository>,
+    /// Provider config repository.
+    provider_config_repo: Arc<dyn ProviderConfigRepository>,
 }
 
 impl AppState {
     /// Create app state backed by PostgreSQL.
     pub fn new(db: PgPool, redis: redis::Client) -> Self {
         let repo = Arc::new(PgRepository::new(db.clone()));
+        let provider_config_repo = Arc::new(PgProviderConfigRepository::new(db.clone()));
         Self {
             db: Some(db),
             redis,
             account_repo: repo.clone(),
             message_repo: repo.clone(),
             api_key_repo: repo,
+            provider_config_repo,
         }
     }
 
@@ -40,6 +45,7 @@ impl AppState {
         account_repo: Arc<dyn AccountRepository>,
         message_repo: Arc<dyn MessageRepository>,
         api_key_repo: Arc<dyn ApiKeyRepository>,
+        provider_config_repo: Arc<dyn ProviderConfigRepository>,
     ) -> Self {
         Self {
             db: None,
@@ -47,6 +53,7 @@ impl AppState {
             account_repo,
             message_repo,
             api_key_repo,
+            provider_config_repo,
         }
     }
 
@@ -63,6 +70,11 @@ impl AppState {
     /// Access the API key repository.
     pub fn api_key_repo(&self) -> Arc<dyn ApiKeyRepository> {
         Arc::clone(&self.api_key_repo)
+    }
+
+    /// Access the provider config repository.
+    pub fn provider_config_repo(&self) -> Arc<dyn ProviderConfigRepository> {
+        Arc::clone(&self.provider_config_repo)
     }
 }
 

--- a/crates/chorus-server/src/app.rs
+++ b/crates/chorus-server/src/app.rs
@@ -93,5 +93,14 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/v1/keys/{id}", delete(routes::keys::revoke_key))
         .route("/v1/otp/send", post(routes::otp::send_otp))
         .route("/v1/otp/verify", post(routes::otp::verify_otp))
+        .route(
+            "/v1/providers",
+            get(routes::provider_configs::list_provider_configs)
+                .post(routes::provider_configs::create_provider_config),
+        )
+        .route(
+            "/v1/providers/{id}",
+            delete(routes::provider_configs::delete_provider_config),
+        )
         .with_state(state)
 }

--- a/crates/chorus-server/src/config.rs
+++ b/crates/chorus-server/src/config.rs
@@ -8,6 +8,46 @@ pub struct Config {
     pub host: String,
     /// Bind port.
     pub port: u16,
+    /// Number of concurrent queue workers.
+    pub worker_concurrency: usize,
+
+    // SMS providers (global defaults)
+    /// Telnyx API key.
+    pub telnyx_api_key: Option<String>,
+    /// Telnyx sender phone number.
+    pub telnyx_from: Option<String>,
+    /// Twilio account SID.
+    pub twilio_account_sid: Option<String>,
+    /// Twilio auth token.
+    pub twilio_auth_token: Option<String>,
+    /// Twilio sender phone number.
+    pub twilio_from: Option<String>,
+    /// Plivo auth ID.
+    pub plivo_auth_id: Option<String>,
+    /// Plivo auth token.
+    pub plivo_auth_token: Option<String>,
+    /// Plivo sender phone number.
+    pub plivo_from: Option<String>,
+
+    // Email providers (global defaults)
+    /// Resend API key.
+    pub resend_api_key: Option<String>,
+    /// AWS SES access key.
+    pub ses_access_key: Option<String>,
+    /// AWS SES secret key.
+    pub ses_secret_key: Option<String>,
+    /// AWS SES region.
+    pub ses_region: Option<String>,
+    /// SMTP server host.
+    pub smtp_host: Option<String>,
+    /// SMTP server port.
+    pub smtp_port: Option<u16>,
+    /// SMTP username.
+    pub smtp_username: Option<String>,
+    /// SMTP password.
+    pub smtp_password: Option<String>,
+    /// Default sender email address.
+    pub from_email: Option<String>,
 }
 
 impl Config {
@@ -23,6 +63,29 @@ impl Config {
                 .ok()
                 .and_then(|p| p.parse().ok())
                 .unwrap_or(3000),
+            worker_concurrency: std::env::var("WORKER_CONCURRENCY")
+                .ok()
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(4),
+
+            telnyx_api_key: std::env::var("TELNYX_API_KEY").ok(),
+            telnyx_from: std::env::var("TELNYX_FROM").ok(),
+            twilio_account_sid: std::env::var("TWILIO_ACCOUNT_SID").ok(),
+            twilio_auth_token: std::env::var("TWILIO_AUTH_TOKEN").ok(),
+            twilio_from: std::env::var("TWILIO_FROM").ok(),
+            plivo_auth_id: std::env::var("PLIVO_AUTH_ID").ok(),
+            plivo_auth_token: std::env::var("PLIVO_AUTH_TOKEN").ok(),
+            plivo_from: std::env::var("PLIVO_FROM").ok(),
+
+            resend_api_key: std::env::var("RESEND_API_KEY").ok(),
+            ses_access_key: std::env::var("AWS_SES_ACCESS_KEY").ok(),
+            ses_secret_key: std::env::var("AWS_SES_SECRET_KEY").ok(),
+            ses_region: std::env::var("AWS_SES_REGION").ok(),
+            smtp_host: std::env::var("SMTP_HOST").ok(),
+            smtp_port: std::env::var("SMTP_PORT").ok().and_then(|p| p.parse().ok()),
+            smtp_username: std::env::var("SMTP_USERNAME").ok(),
+            smtp_password: std::env::var("SMTP_PASSWORD").ok(),
+            from_email: std::env::var("FROM_EMAIL").ok(),
         }
     }
 }

--- a/crates/chorus-server/src/db/migrations/002_provider_configs.sql
+++ b/crates/chorus-server/src/db/migrations/002_provider_configs.sql
@@ -1,0 +1,14 @@
+CREATE TABLE provider_configs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id UUID NOT NULL REFERENCES accounts(id),
+    channel TEXT NOT NULL CHECK (channel IN ('sms', 'email')),
+    provider TEXT NOT NULL,
+    priority INTEGER NOT NULL,
+    credentials JSONB NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (account_id, channel, provider)
+);
+
+CREATE INDEX idx_provider_configs_account_channel
+    ON provider_configs(account_id, channel);

--- a/crates/chorus-server/src/db/mod.rs
+++ b/crates/chorus-server/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod postgres;
+pub mod provider_config;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -137,6 +138,48 @@ pub trait MessageRepository: Send + Sync {
 
     /// Get all delivery events for a message.
     async fn get_delivery_events(&self, message_id: Uuid) -> Result<Vec<DeliveryEvent>, DbError>;
+}
+
+/// A provider configuration for per-account routing.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ProviderConfig {
+    pub id: Uuid,
+    pub account_id: Uuid,
+    pub channel: String,
+    pub provider: String,
+    pub priority: i32,
+    pub credentials: serde_json::Value,
+    pub is_active: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Parameters for inserting a new provider config.
+pub struct NewProviderConfig {
+    pub account_id: Uuid,
+    pub channel: String,
+    pub provider: String,
+    pub priority: i32,
+    pub credentials: serde_json::Value,
+}
+
+/// Per-account provider configuration management.
+#[async_trait]
+pub trait ProviderConfigRepository: Send + Sync {
+    /// List active provider configs for an account+channel, ordered by priority.
+    async fn list_by_account_channel(
+        &self,
+        account_id: Uuid,
+        channel: &str,
+    ) -> Result<Vec<ProviderConfig>, DbError>;
+
+    /// Insert a new provider config.
+    async fn insert(&self, config: &NewProviderConfig) -> Result<ProviderConfig, DbError>;
+
+    /// List all provider configs for an account.
+    async fn list_by_account(&self, account_id: Uuid) -> Result<Vec<ProviderConfig>, DbError>;
+
+    /// Delete a provider config.
+    async fn delete(&self, id: Uuid, account_id: Uuid) -> Result<(), DbError>;
 }
 
 /// API key management operations.

--- a/crates/chorus-server/src/db/provider_config.rs
+++ b/crates/chorus-server/src/db/provider_config.rs
@@ -1,0 +1,79 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::{DbError, NewProviderConfig, ProviderConfig, ProviderConfigRepository};
+
+/// PostgreSQL-backed provider config repository.
+pub struct PgProviderConfigRepository {
+    pool: PgPool,
+}
+
+impl PgProviderConfigRepository {
+    /// Create a new repository backed by the given connection pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ProviderConfigRepository for PgProviderConfigRepository {
+    async fn list_by_account_channel(
+        &self,
+        account_id: Uuid,
+        channel: &str,
+    ) -> Result<Vec<ProviderConfig>, DbError> {
+        sqlx::query_as::<_, ProviderConfig>(
+            "SELECT * FROM provider_configs
+             WHERE account_id = $1 AND channel = $2 AND is_active = true
+             ORDER BY priority ASC",
+        )
+        .bind(account_id)
+        .bind(channel)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))
+    }
+
+    async fn insert(&self, config: &NewProviderConfig) -> Result<ProviderConfig, DbError> {
+        sqlx::query_as::<_, ProviderConfig>(
+            "INSERT INTO provider_configs (account_id, channel, provider, priority, credentials)
+             VALUES ($1, $2, $3, $4, $5)
+             RETURNING *",
+        )
+        .bind(config.account_id)
+        .bind(&config.channel)
+        .bind(&config.provider)
+        .bind(config.priority)
+        .bind(&config.credentials)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))
+    }
+
+    async fn list_by_account(&self, account_id: Uuid) -> Result<Vec<ProviderConfig>, DbError> {
+        sqlx::query_as::<_, ProviderConfig>(
+            "SELECT * FROM provider_configs WHERE account_id = $1 ORDER BY channel, priority ASC",
+        )
+        .bind(account_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))
+    }
+
+    async fn delete(&self, id: Uuid, account_id: Uuid) -> Result<(), DbError> {
+        let result = sqlx::query(
+            "DELETE FROM provider_configs WHERE id = $1 AND account_id = $2",
+        )
+        .bind(id)
+        .bind(account_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(DbError::NotFound);
+        }
+        Ok(())
+    }
+}

--- a/crates/chorus-server/src/db/provider_config.rs
+++ b/crates/chorus-server/src/db/provider_config.rs
@@ -62,14 +62,12 @@ impl ProviderConfigRepository for PgProviderConfigRepository {
     }
 
     async fn delete(&self, id: Uuid, account_id: Uuid) -> Result<(), DbError> {
-        let result = sqlx::query(
-            "DELETE FROM provider_configs WHERE id = $1 AND account_id = $2",
-        )
-        .bind(id)
-        .bind(account_id)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| DbError::Internal(e.into()))?;
+        let result = sqlx::query("DELETE FROM provider_configs WHERE id = $1 AND account_id = $2")
+            .bind(id)
+            .bind(account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DbError::Internal(e.into()))?;
 
         if result.rows_affected() == 0 {
             return Err(DbError::NotFound);

--- a/crates/chorus-server/src/main.rs
+++ b/crates/chorus-server/src/main.rs
@@ -13,18 +13,22 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let config = Config::from_env();
+    let config = Arc::new(Config::from_env());
 
     let db = sqlx::PgPool::connect(&config.database_url).await?;
     sqlx::migrate!("src/db/migrations").run(&db).await?;
 
     let redis = redis::Client::open(config.redis_url.as_str())?;
-
     let state = AppState::new(db, redis);
     let state = Arc::new(state);
 
-    // Spawn background queue worker
-    chorus_server::queue::worker::spawn_worker(Arc::clone(&state));
+    // Spawn background queue workers and delayed poller
+    chorus_server::queue::worker::spawn_workers(
+        Arc::clone(&state),
+        Arc::clone(&config),
+        config.worker_concurrency,
+    );
+    chorus_server::queue::delayed::spawn_delayed_poller(state.redis.clone());
 
     let app = create_router(state);
 

--- a/crates/chorus-server/src/queue/dead_letter.rs
+++ b/crates/chorus-server/src/queue/dead_letter.rs
@@ -1,0 +1,14 @@
+/// Push a failed job to the dead letter queue.
+pub async fn push_to_dlq(redis: &redis::Client, job: &super::SendJob) -> anyhow::Result<()> {
+    let mut conn = redis.get_multiplexed_tokio_connection().await?;
+    let payload = serde_json::to_string(job)?;
+
+    redis::cmd("LPUSH")
+        .arg(super::DEAD_LETTER_KEY)
+        .arg(payload)
+        .query_async::<i64>(&mut conn)
+        .await?;
+
+    tracing::warn!(message_id = %job.message_id, "job moved to dead letter queue");
+    Ok(())
+}

--- a/crates/chorus-server/src/queue/delayed.rs
+++ b/crates/chorus-server/src/queue/delayed.rs
@@ -1,0 +1,77 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Spawn the delayed queue poller that moves due jobs back to the main queue.
+pub fn spawn_delayed_poller(redis: redis::Client) {
+    tokio::spawn(async move {
+        tracing::info!("delayed queue poller started");
+        loop {
+            if let Err(e) = poll_delayed_jobs(&redis).await {
+                tracing::error!("delayed poller error: {e}");
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    });
+}
+
+/// Move jobs whose retry-at timestamp has passed back to the main queue.
+async fn poll_delayed_jobs(redis: &redis::Client) -> anyhow::Result<()> {
+    let mut conn = redis.get_multiplexed_tokio_connection().await?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_secs();
+
+    // Fetch jobs that are due (score <= now)
+    let jobs: Vec<String> = redis::cmd("ZRANGEBYSCORE")
+        .arg(super::DELAYED_KEY)
+        .arg("-inf")
+        .arg(now)
+        .query_async(&mut conn)
+        .await?;
+
+    for payload in jobs {
+        // Atomically remove from delayed set — if ZREM returns 0, another poller got it
+        let removed: i64 = redis::cmd("ZREM")
+            .arg(super::DELAYED_KEY)
+            .arg(&payload)
+            .query_async(&mut conn)
+            .await?;
+
+        if removed > 0 {
+            redis::cmd("LPUSH")
+                .arg(super::QUEUE_KEY)
+                .arg(&payload)
+                .query_async::<i64>(&mut conn)
+                .await?;
+            tracing::debug!("moved delayed job back to main queue");
+        }
+    }
+
+    Ok(())
+}
+
+/// Schedule a job for retry after exponential backoff.
+pub async fn schedule_retry(redis: &redis::Client, job: &super::SendJob) -> anyhow::Result<()> {
+    let mut conn = redis.get_multiplexed_tokio_connection().await?;
+    let backoff_secs = 1u64 << job.attempt.min(10) as u64; // 2^attempt: 1, 2, 4, ...
+    let retry_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_secs()
+        + backoff_secs;
+
+    let payload = serde_json::to_string(job)?;
+    redis::cmd("ZADD")
+        .arg(super::DELAYED_KEY)
+        .arg(retry_at)
+        .arg(payload)
+        .query_async::<i64>(&mut conn)
+        .await?;
+
+    tracing::debug!(
+        message_id = %job.message_id,
+        attempt = job.attempt,
+        backoff_secs,
+        "scheduled retry"
+    );
+
+    Ok(())
+}

--- a/crates/chorus-server/src/queue/delayed.rs
+++ b/crates/chorus-server/src/queue/delayed.rs
@@ -16,9 +16,7 @@ pub fn spawn_delayed_poller(redis: redis::Client) {
 /// Move jobs whose retry-at timestamp has passed back to the main queue.
 async fn poll_delayed_jobs(redis: &redis::Client) -> anyhow::Result<()> {
     let mut conn = redis.get_multiplexed_tokio_connection().await?;
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)?
-        .as_secs();
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
     // Fetch jobs that are due (score <= now)
     let jobs: Vec<String> = redis::cmd("ZRANGEBYSCORE")
@@ -53,10 +51,7 @@ async fn poll_delayed_jobs(redis: &redis::Client) -> anyhow::Result<()> {
 pub async fn schedule_retry(redis: &redis::Client, job: &super::SendJob) -> anyhow::Result<()> {
     let mut conn = redis.get_multiplexed_tokio_connection().await?;
     let backoff_secs = 1u64 << job.attempt.min(10) as u64; // 2^attempt: 1, 2, 4, ...
-    let retry_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)?
-        .as_secs()
-        + backoff_secs;
+    let retry_at = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() + backoff_secs;
 
     let payload = serde_json::to_string(job)?;
     redis::cmd("ZADD")

--- a/crates/chorus-server/src/queue/enqueue.rs
+++ b/crates/chorus-server/src/queue/enqueue.rs
@@ -1,13 +1,11 @@
 use crate::app::AppState;
 
-const QUEUE_KEY: &str = "chorus:jobs";
-
 /// Push a send job onto the Redis queue.
 pub async fn enqueue_job(state: &AppState, job: &super::SendJob) -> anyhow::Result<()> {
     let mut conn = state.redis.get_multiplexed_tokio_connection().await?;
     let payload = serde_json::to_string(job)?;
     redis::cmd("LPUSH")
-        .arg(QUEUE_KEY)
+        .arg(super::QUEUE_KEY)
         .arg(payload)
         .query_async::<i64>(&mut conn)
         .await?;

--- a/crates/chorus-server/src/queue/mod.rs
+++ b/crates/chorus-server/src/queue/mod.rs
@@ -1,4 +1,5 @@
 pub mod enqueue;
+pub mod router_builder;
 pub mod worker;
 
 use serde::{Deserialize, Serialize};

--- a/crates/chorus-server/src/queue/mod.rs
+++ b/crates/chorus-server/src/queue/mod.rs
@@ -1,9 +1,20 @@
+pub mod dead_letter;
+pub mod delayed;
 pub mod enqueue;
 pub mod router_builder;
 pub mod worker;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+/// Main work queue key.
+pub const QUEUE_KEY: &str = "chorus:jobs";
+/// Delayed retry queue (sorted set, score = retry-at Unix timestamp).
+pub const DELAYED_KEY: &str = "chorus:delayed";
+/// Dead letter queue for permanently failed jobs.
+pub const DEAD_LETTER_KEY: &str = "chorus:dead_letters";
+/// Maximum delivery attempts before moving to DLQ.
+pub const MAX_RETRIES: i32 = 3;
 
 /// A job representing a message to be sent.
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,4 +27,6 @@ pub struct SendJob {
     pub channel: String,
     /// `"live"` or `"test"`.
     pub environment: String,
+    /// Current attempt number (0-based, incremented on retry).
+    pub attempt: i32,
 }

--- a/crates/chorus-server/src/queue/router_builder.rs
+++ b/crates/chorus-server/src/queue/router_builder.rs
@@ -1,0 +1,170 @@
+use chorus_core::router::WaterfallRouter;
+use chorus_providers::email::mock::MockEmailSender;
+use chorus_providers::email::resend::ResendEmailSender;
+use chorus_providers::email::ses::SesEmailSender;
+use chorus_providers::email::smtp::SmtpEmailSender;
+use chorus_providers::sms::mock::MockSmsSender;
+use chorus_providers::sms::plivo::PlivoSmsSender;
+use chorus_providers::sms::telnyx::TelnyxSmsSender;
+use chorus_providers::sms::twilio::TwilioSmsSender;
+use std::sync::Arc;
+
+use crate::config::Config;
+use crate::db::ProviderConfig;
+
+/// Build a router for test mode — always mock providers.
+pub fn build_test_router(channel: &str) -> WaterfallRouter {
+    let mut router = WaterfallRouter::new();
+    match channel {
+        "sms" => router = router.add_sms(Arc::new(MockSmsSender)),
+        "email" => router = router.add_email(Arc::new(MockEmailSender)),
+        _ => {}
+    }
+    router
+}
+
+/// Build a router from per-account provider configs (priority order).
+pub fn build_router_from_configs(
+    configs: &[ProviderConfig],
+) -> anyhow::Result<WaterfallRouter> {
+    let mut router = WaterfallRouter::new();
+
+    for config in configs {
+        router = add_provider_to_router(
+            router,
+            &config.provider,
+            &config.channel,
+            &config.credentials,
+        )?;
+    }
+
+    Ok(router)
+}
+
+/// Build a router from global env var defaults.
+pub fn build_router_from_env(config: &Config, channel: &str) -> anyhow::Result<WaterfallRouter> {
+    let mut router = WaterfallRouter::new();
+
+    match channel {
+        "sms" => {
+            if let Some(ref api_key) = config.telnyx_api_key {
+                router = router.add_sms(Arc::new(TelnyxSmsSender::new(
+                    api_key.clone(),
+                    config.telnyx_from.clone(),
+                )));
+            }
+            if let (Some(ref sid), Some(ref token)) =
+                (&config.twilio_account_sid, &config.twilio_auth_token)
+            {
+                router = router.add_sms(Arc::new(TwilioSmsSender::new(
+                    sid.clone(),
+                    token.clone(),
+                    config.twilio_from.clone(),
+                )));
+            }
+            if let (Some(ref id), Some(ref token)) =
+                (&config.plivo_auth_id, &config.plivo_auth_token)
+            {
+                router = router.add_sms(Arc::new(PlivoSmsSender::new(
+                    id.clone(),
+                    token.clone(),
+                    config.plivo_from.clone(),
+                )));
+            }
+        }
+        "email" => {
+            if let (Some(ref api_key), Some(ref from)) =
+                (&config.resend_api_key, &config.from_email)
+            {
+                router = router.add_email(Arc::new(ResendEmailSender::new(
+                    api_key.clone(),
+                    from.clone(),
+                )));
+            }
+            if let (Some(ref ak), Some(ref sk), Some(ref region), Some(ref from)) = (
+                &config.ses_access_key,
+                &config.ses_secret_key,
+                &config.ses_region,
+                &config.from_email,
+            ) {
+                let sender = SesEmailSender::new(
+                    ak.clone(),
+                    sk.clone(),
+                    region.clone(),
+                    from.clone(),
+                )?;
+                router = router.add_email(Arc::new(sender));
+            }
+            if let (Some(ref host), Some(port), Some(ref user), Some(ref pass), Some(ref from)) = (
+                &config.smtp_host,
+                config.smtp_port,
+                &config.smtp_username,
+                &config.smtp_password,
+                &config.from_email,
+            ) {
+                let sender = SmtpEmailSender::new(
+                    host.clone(),
+                    port,
+                    user.clone(),
+                    pass.clone(),
+                    from.clone(),
+                )?;
+                router = router.add_email(Arc::new(sender));
+            }
+        }
+        _ => {}
+    }
+
+    Ok(router)
+}
+
+/// Add a single provider to a router based on provider name and credentials JSON.
+fn add_provider_to_router(
+    router: WaterfallRouter,
+    provider: &str,
+    channel: &str,
+    creds: &serde_json::Value,
+) -> anyhow::Result<WaterfallRouter> {
+    match (channel, provider) {
+        ("sms", "telnyx") => {
+            let api_key = creds["api_key"].as_str().unwrap_or_default().to_string();
+            let from = creds["from"].as_str().map(String::from);
+            Ok(router.add_sms(Arc::new(TelnyxSmsSender::new(api_key, from))))
+        }
+        ("sms", "twilio") => {
+            let sid = creds["account_sid"].as_str().unwrap_or_default().to_string();
+            let token = creds["auth_token"].as_str().unwrap_or_default().to_string();
+            let from = creds["from"].as_str().map(String::from);
+            Ok(router.add_sms(Arc::new(TwilioSmsSender::new(sid, token, from))))
+        }
+        ("sms", "plivo") => {
+            let id = creds["auth_id"].as_str().unwrap_or_default().to_string();
+            let token = creds["auth_token"].as_str().unwrap_or_default().to_string();
+            let from = creds["from"].as_str().map(String::from);
+            Ok(router.add_sms(Arc::new(PlivoSmsSender::new(id, token, from))))
+        }
+        ("email", "resend") => {
+            let api_key = creds["api_key"].as_str().unwrap_or_default().to_string();
+            let from = creds["from"].as_str().unwrap_or_default().to_string();
+            Ok(router.add_email(Arc::new(ResendEmailSender::new(api_key, from))))
+        }
+        ("email", "ses") => {
+            let ak = creds["access_key"].as_str().unwrap_or_default().to_string();
+            let sk = creds["secret_key"].as_str().unwrap_or_default().to_string();
+            let region = creds["region"].as_str().unwrap_or_default().to_string();
+            let from = creds["from"].as_str().unwrap_or_default().to_string();
+            let sender = SesEmailSender::new(ak, sk, region, from)?;
+            Ok(router.add_email(Arc::new(sender)))
+        }
+        ("email", "smtp") => {
+            let host = creds["host"].as_str().unwrap_or_default().to_string();
+            let port = creds["port"].as_u64().unwrap_or(587) as u16;
+            let user = creds["username"].as_str().unwrap_or_default().to_string();
+            let pass = creds["password"].as_str().unwrap_or_default().to_string();
+            let from = creds["from"].as_str().unwrap_or_default().to_string();
+            let sender = SmtpEmailSender::new(host, port, user, pass, from)?;
+            Ok(router.add_email(Arc::new(sender)))
+        }
+        _ => anyhow::bail!("unknown provider: {channel}/{provider}"),
+    }
+}

--- a/crates/chorus-server/src/queue/router_builder.rs
+++ b/crates/chorus-server/src/queue/router_builder.rs
@@ -24,9 +24,7 @@ pub fn build_test_router(channel: &str) -> WaterfallRouter {
 }
 
 /// Build a router from per-account provider configs (priority order).
-pub fn build_router_from_configs(
-    configs: &[ProviderConfig],
-) -> anyhow::Result<WaterfallRouter> {
+pub fn build_router_from_configs(configs: &[ProviderConfig]) -> anyhow::Result<WaterfallRouter> {
     let mut router = WaterfallRouter::new();
 
     for config in configs {
@@ -87,12 +85,8 @@ pub fn build_router_from_env(config: &Config, channel: &str) -> anyhow::Result<W
                 &config.ses_region,
                 &config.from_email,
             ) {
-                let sender = SesEmailSender::new(
-                    ak.clone(),
-                    sk.clone(),
-                    region.clone(),
-                    from.clone(),
-                )?;
+                let sender =
+                    SesEmailSender::new(ak.clone(), sk.clone(), region.clone(), from.clone())?;
                 router = router.add_email(Arc::new(sender));
             }
             if let (Some(ref host), Some(port), Some(ref user), Some(ref pass), Some(ref from)) = (
@@ -132,7 +126,10 @@ fn add_provider_to_router(
             Ok(router.add_sms(Arc::new(TelnyxSmsSender::new(api_key, from))))
         }
         ("sms", "twilio") => {
-            let sid = creds["account_sid"].as_str().unwrap_or_default().to_string();
+            let sid = creds["account_sid"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string();
             let token = creds["auth_token"].as_str().unwrap_or_default().to_string();
             let from = creds["from"].as_str().map(String::from);
             Ok(router.add_sms(Arc::new(TwilioSmsSender::new(sid, token, from))))

--- a/crates/chorus-server/src/queue/worker.rs
+++ b/crates/chorus-server/src/queue/worker.rs
@@ -133,15 +133,9 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
         }
         Err(e) => {
             let error_msg = e.to_string();
-            repo.update_status(
-                job.message_id,
-                "retrying",
-                None,
-                None,
-                Some(&error_msg),
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            repo.update_status(job.message_id, "retrying", None, None, Some(&error_msg))
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
             repo.insert_delivery_event(
                 job.message_id,
                 "failed_attempt",

--- a/crates/chorus-server/src/queue/worker.rs
+++ b/crates/chorus-server/src/queue/worker.rs
@@ -1,30 +1,32 @@
+use chorus_core::types::{EmailMessage, SmsMessage};
 use std::sync::Arc;
 
 use crate::app::AppState;
+use crate::config::Config;
 
-const QUEUE_KEY: &str = "chorus:jobs";
-const MAX_RETRIES: i32 = 3;
-
-/// Spawn the background worker that processes queued messages.
-pub fn spawn_worker(state: Arc<AppState>) {
-    tokio::spawn(async move {
-        tracing::info!("queue worker started");
-        loop {
-            if let Err(e) = process_next_job(&state).await {
-                tracing::error!("worker error: {e}");
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+/// Spawn N worker tasks that process jobs from the main queue.
+pub fn spawn_workers(state: Arc<AppState>, config: Arc<Config>, concurrency: usize) {
+    for i in 0..concurrency {
+        let state = Arc::clone(&state);
+        let config = Arc::clone(&config);
+        tokio::spawn(async move {
+            tracing::info!(worker = i, "queue worker started");
+            loop {
+                if let Err(e) = process_next_job(&state, &config).await {
+                    tracing::error!(worker = i, "worker error: {e}");
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
             }
-        }
-    });
+        });
+    }
 }
 
 /// Block-pop the next job from Redis and process it.
-async fn process_next_job(state: &Arc<AppState>) -> anyhow::Result<()> {
+async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Result<()> {
     let mut conn = state.redis.get_multiplexed_tokio_connection().await?;
 
-    // BRPOP blocks until a job is available (timeout 5s)
     let result: Option<(String, String)> = redis::cmd("BRPOP")
-        .arg(QUEUE_KEY)
+        .arg(super::QUEUE_KEY)
         .arg(5)
         .query_async(&mut conn)
         .await?;
@@ -43,7 +45,8 @@ async fn process_next_job(state: &Arc<AppState>) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("{e}"))?
         .ok_or_else(|| anyhow::anyhow!("message {} not found", job.message_id))?;
 
-    if message.attempts >= MAX_RETRIES {
+    // Max retries exceeded → DLQ
+    if job.attempt >= super::MAX_RETRIES {
         repo.update_status(
             job.message_id,
             "failed",
@@ -56,41 +59,108 @@ async fn process_next_job(state: &Arc<AppState>) -> anyhow::Result<()> {
         repo.insert_delivery_event(
             job.message_id,
             "failed",
-            Some(serde_json::json!({"reason": "max retries exceeded"})),
+            Some(serde_json::json!({"reason": "max retries exceeded", "attempts": job.attempt})),
         )
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        super::dead_letter::push_to_dlq(&state.redis, &job).await?;
         return Ok(());
     }
 
-    // In test environment, just mark as delivered without sending
-    if job.environment == "test" {
-        repo.update_status(
-            job.message_id,
-            "delivered",
-            Some("mock"),
-            Some("test-mock-id"),
-            None,
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-        repo.insert_delivery_event(
-            job.message_id,
-            "delivered",
-            Some(serde_json::json!({"provider": "mock", "environment": "test"})),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-        return Ok(());
-    }
+    // Build router based on environment
+    let router = if job.environment == "test" {
+        super::router_builder::build_test_router(&job.channel)
+    } else {
+        // Try per-account config, fall back to env defaults
+        let configs = state
+            .provider_config_repo()
+            .list_by_account_channel(job.account_id, &job.channel)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    // Live sending will be implemented when provider config is wired up
-    repo.update_status(job.message_id, "sent", None, None, None)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    repo.insert_delivery_event(job.message_id, "sent", None)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if configs.is_empty() {
+            super::router_builder::build_router_from_env(config, &job.channel)?
+        } else {
+            super::router_builder::build_router_from_configs(&configs)?
+        }
+    };
+
+    // Send via chorus-core
+    let send_result = match job.channel.as_str() {
+        "sms" => {
+            let msg = SmsMessage {
+                to: message.recipient.clone(),
+                body: message.body.clone(),
+                from: message.sender.clone(),
+            };
+            router.send_sms(&msg).await
+        }
+        "email" => {
+            let msg = EmailMessage {
+                to: message.recipient.clone(),
+                subject: message.subject.clone().unwrap_or_default(),
+                html_body: message.body.clone(),
+                text_body: message.body.clone(),
+                from: message.sender.clone(),
+            };
+            router.send_email(&msg).await
+        }
+        _ => anyhow::bail!("unknown channel: {}", job.channel),
+    };
+
+    match send_result {
+        Ok(result) => {
+            repo.update_status(
+                job.message_id,
+                "delivered",
+                Some(&result.provider),
+                Some(&result.message_id),
+                None,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            repo.insert_delivery_event(
+                job.message_id,
+                "delivered",
+                Some(serde_json::json!({
+                    "provider": result.provider,
+                    "provider_message_id": result.message_id,
+                })),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+        Err(e) => {
+            let error_msg = e.to_string();
+            repo.update_status(
+                job.message_id,
+                "retrying",
+                None,
+                None,
+                Some(&error_msg),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            repo.insert_delivery_event(
+                job.message_id,
+                "failed_attempt",
+                Some(serde_json::json!({
+                    "attempt": job.attempt,
+                    "error": error_msg,
+                })),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            // Schedule retry with incremented attempt
+            let retry_job = super::SendJob {
+                attempt: job.attempt + 1,
+                ..job
+            };
+            super::delayed::schedule_retry(&state.redis, &retry_job).await?;
+        }
+    }
 
     Ok(())
 }

--- a/crates/chorus-server/src/routes/email.rs
+++ b/crates/chorus-server/src/routes/email.rs
@@ -51,6 +51,7 @@ pub async fn send_email(
         account_id: message.account_id,
         channel: "email".into(),
         environment: message.environment.clone(),
+        attempt: 0,
     };
     crate::queue::enqueue::enqueue_job(&state, &job)
         .await

--- a/crates/chorus-server/src/routes/mod.rs
+++ b/crates/chorus-server/src/routes/mod.rs
@@ -3,4 +3,5 @@ pub mod health;
 pub mod keys;
 pub mod messages;
 pub mod otp;
+pub mod provider_configs;
 pub mod sms;

--- a/crates/chorus-server/src/routes/otp.rs
+++ b/crates/chorus-server/src/routes/otp.rs
@@ -76,6 +76,7 @@ pub async fn send_otp(
         account_id: message.account_id,
         channel: message.channel.clone(),
         environment: _ctx.environment,
+        attempt: 0,
     };
     crate::queue::enqueue::enqueue_job(&state, &job)
         .await

--- a/crates/chorus-server/src/routes/provider_configs.rs
+++ b/crates/chorus-server/src/routes/provider_configs.rs
@@ -44,11 +44,17 @@ pub async fn create_provider_config(
     Json(req): Json<CreateProviderConfigRequest>,
 ) -> Result<(StatusCode, Json<ProviderConfig>), (StatusCode, String)> {
     if !VALID_CHANNELS.contains(&req.channel.as_str()) {
-        return Err((StatusCode::BAD_REQUEST, "channel must be 'sms' or 'email'".into()));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "channel must be 'sms' or 'email'".into(),
+        ));
     }
 
     if !VALID_PROVIDERS.contains(&req.provider.as_str()) {
-        return Err((StatusCode::BAD_REQUEST, format!("unknown provider: {}", req.provider)));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("unknown provider: {}", req.provider),
+        ));
     }
 
     let config = state

--- a/crates/chorus-server/src/routes/provider_configs.rs
+++ b/crates/chorus-server/src/routes/provider_configs.rs
@@ -1,0 +1,82 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::api_key::AccountContext;
+use crate::db::{NewProviderConfig, ProviderConfig};
+
+/// Request body for adding a provider config.
+#[derive(Deserialize)]
+pub struct CreateProviderConfigRequest {
+    pub channel: String,
+    pub provider: String,
+    pub priority: i32,
+    pub credentials: serde_json::Value,
+}
+
+/// Valid channel names.
+const VALID_CHANNELS: &[&str] = &["sms", "email"];
+/// Valid provider names.
+const VALID_PROVIDERS: &[&str] = &["telnyx", "twilio", "plivo", "resend", "ses", "smtp"];
+
+/// List all provider configs for the authenticated account.
+pub async fn list_provider_configs(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+) -> Result<Json<Vec<ProviderConfig>>, (StatusCode, String)> {
+    let configs = state
+        .provider_config_repo()
+        .list_by_account(ctx.account_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(configs))
+}
+
+/// Add a provider config for the authenticated account.
+pub async fn create_provider_config(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Json(req): Json<CreateProviderConfigRequest>,
+) -> Result<(StatusCode, Json<ProviderConfig>), (StatusCode, String)> {
+    if !VALID_CHANNELS.contains(&req.channel.as_str()) {
+        return Err((StatusCode::BAD_REQUEST, "channel must be 'sms' or 'email'".into()));
+    }
+
+    if !VALID_PROVIDERS.contains(&req.provider.as_str()) {
+        return Err((StatusCode::BAD_REQUEST, format!("unknown provider: {}", req.provider)));
+    }
+
+    let config = state
+        .provider_config_repo()
+        .insert(&NewProviderConfig {
+            account_id: ctx.account_id,
+            channel: req.channel,
+            provider: req.provider,
+            priority: req.priority,
+            credentials: req.credentials,
+        })
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(config)))
+}
+
+/// Delete a provider config.
+pub async fn delete_provider_config(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .provider_config_repo()
+        .delete(id, ctx.account_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/chorus-server/src/routes/sms.rs
+++ b/crates/chorus-server/src/routes/sms.rs
@@ -57,6 +57,7 @@ pub async fn send_sms(
         account_id: message.account_id,
         channel: "sms".into(),
         environment: message.environment.clone(),
+        attempt: 0,
     };
     crate::queue::enqueue::enqueue_job(&state, &job)
         .await

--- a/crates/chorus-server/tests/api_test.rs
+++ b/crates/chorus-server/tests/api_test.rs
@@ -12,7 +12,8 @@ use uuid::Uuid;
 use chorus_server::app::{create_router, AppState};
 use chorus_server::db::{
     Account, AccountRepository, ApiKey, ApiKeyRepository, DbError, DeliveryEvent, Message,
-    MessageRepository, NewMessage, Pagination,
+    MessageRepository, NewMessage, NewProviderConfig, Pagination, ProviderConfig,
+    ProviderConfigRepository,
 };
 
 // ---------------------------------------------------------------------------
@@ -161,6 +162,40 @@ impl ApiKeyRepository for MockApiKeyRepo {
     }
 }
 
+struct MockProviderConfigRepo;
+
+#[async_trait]
+impl ProviderConfigRepository for MockProviderConfigRepo {
+    async fn list_by_account_channel(
+        &self,
+        _account_id: Uuid,
+        _channel: &str,
+    ) -> Result<Vec<ProviderConfig>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn insert(&self, config: &NewProviderConfig) -> Result<ProviderConfig, DbError> {
+        Ok(ProviderConfig {
+            id: Uuid::new_v4(),
+            account_id: config.account_id,
+            channel: config.channel.clone(),
+            provider: config.provider.clone(),
+            priority: config.priority,
+            credentials: config.credentials.clone(),
+            is_active: true,
+            created_at: Utc::now(),
+        })
+    }
+
+    async fn list_by_account(&self, _account_id: Uuid) -> Result<Vec<ProviderConfig>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn delete(&self, _id: Uuid, _account_id: Uuid) -> Result<(), DbError> {
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -198,6 +233,7 @@ fn test_state() -> Arc<AppState> {
 
     let message_repo = Arc::new(MockMessageRepo::new());
     let api_key_repo = Arc::new(MockApiKeyRepo);
+    let provider_config_repo = Arc::new(MockProviderConfigRepo);
 
     // Use a dummy Redis URL — tests that hit Redis will fail,
     // but auth + DB-only tests will work
@@ -208,6 +244,7 @@ fn test_state() -> Arc<AppState> {
         account_repo,
         message_repo,
         api_key_repo,
+        provider_config_repo,
     ))
 }
 
@@ -324,4 +361,25 @@ async fn keys_list_returns_200() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn providers_list_returns_200() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/providers")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_body(resp).await;
+    assert!(body.as_array().unwrap().is_empty());
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       REDIS_URL: redis://redis:6379
       HOST: 0.0.0.0
       PORT: "3000"
+      WORKER_CONCURRENCY: "4"
       RUST_LOG: chorus_server=debug,tower_http=debug
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary
- **Worker pool:** Replaces single placeholder worker with configurable N-worker pool (`WORKER_CONCURRENCY` env var, default 4)
- **Live delivery:** Workers build `WaterfallRouter` per job — per-account DB config or global env defaults — and send via chorus-core providers (Telnyx, Twilio, Plivo, Resend, SES, SMTP)
- **Retry & DLQ:** Failed deliveries scheduled for exponential-backoff retry via Redis sorted set; permanently failed jobs (3 attempts) moved to dead letter queue
- **Provider config API:** `GET/POST /v1/providers` and `DELETE /v1/providers/{id}` for per-account provider management
- **Migration:** `002_provider_configs.sql` adds `provider_configs` table with priority-ordered multi-provider support

## Test plan
- [x] `cargo test --workspace` — 60 tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] Manual: start server with provider env vars, send SMS/email, verify delivery + retry behavior
- [x] Manual: configure per-account providers via API, verify routing priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2