### PR TITLE
feat: Phase 3 — providers, templates & chorus-mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,7 @@ WORKER_CONCURRENCY=4
 # General
 # FROM_EMAIL=noreply@yourdomain.com
 # FROM_NAME=YourApp
+
+# chorus-mail (self-hosted email)
+# MAIL_DOMAIN=example.com
+# BOUNCE_SECRET=your-shared-secret-here

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +206,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "minijinja",
  "serde",
  "serde_json",
  "thiserror",
@@ -219,6 +230,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -233,8 +245,9 @@ dependencies = [
  "chrono",
  "dotenvy",
  "hex",
+ "hickory-resolver",
  "http-body-util",
- "rand",
+ "rand 0.8.5",
  "redis",
  "serde",
  "serde_json",
@@ -343,6 +356,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +403,30 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -439,6 +500,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -539,6 +612,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +671,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,8 +699,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -632,13 +733,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -695,10 +808,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -1008,6 +1173,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,10 +1363,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "mio"
@@ -1199,6 +1393,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -1257,7 +1468,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1293,10 +1504,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl"
@@ -1426,6 +1651,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1710,12 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1490,8 +1727,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1501,7 +1748,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1511,6 +1768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1553,6 +1819,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1613,6 +1891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,7 +1923,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1874,7 +2158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2049,7 +2333,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -2089,7 +2373,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -2202,6 +2486,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -2699,6 +2989,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +3211,29 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8"
 url = "2"
 
+# Template engine
+minijinja = "2"
+
 # Email (SMTP)
 lettre = { version = "0.11", features = ["tokio1-native-tls"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ url = "2"
 # Template engine
 minijinja = "2"
 
+# DNS resolution
+hickory-resolver = "0.25"
+
 # Email (SMTP)
 lettre = { version = "0.11", features = ["tokio1-native-tls"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ minijinja = "2"
 # DNS resolution
 hickory-resolver = "0.25"
 
+# Testing
+wiremock = "0.6"
+
 # Email (SMTP)
 lettre = { version = "0.11", features = ["tokio1-native-tls"] }
 

--- a/chorus-mail/Dockerfile
+++ b/chorus-mail/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache \
+    postfix \
+    opendkim \
+    opendkim-utils \
+    curl \
+    bash
+
+COPY config/main.cf /etc/postfix/main.cf.template
+COPY config/master.cf /etc/postfix/master.cf
+COPY config/opendkim.conf /etc/opendkim/opendkim.conf.template
+COPY scripts/ /scripts/
+RUN chmod +x /scripts/*.sh
+
+EXPOSE 25 587
+
+ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/chorus-mail/config/main.cf
+++ b/chorus-mail/config/main.cf
@@ -1,0 +1,32 @@
+# Chorus Mail — Postfix main configuration
+# Variables replaced by entrypoint.sh: __MAIL_DOMAIN__, __HOSTNAME__
+
+myhostname = __HOSTNAME__
+mydomain = __MAIL_DOMAIN__
+myorigin = $mydomain
+mydestination = localhost
+mynetworks = 127.0.0.0/8 172.16.0.0/12 10.0.0.0/8 192.168.0.0/16
+
+# TLS
+smtp_tls_security_level = encrypt
+smtp_tls_loglevel = 1
+
+# Submission port (587) — used by chorus-server
+smtpd_sasl_auth_enable = no
+
+# OpenDKIM milter
+milter_default_action = accept
+milter_protocol = 6
+smtpd_milters = inet:localhost:8891
+non_smtpd_milters = inet:localhost:8891
+
+# Bounce handling
+notify_classes = bounce, resource, software
+bounce_notice_recipient = bounce-handler
+
+# Size limits
+message_size_limit = 10240000
+mailbox_size_limit = 0
+
+# Logging
+maillog_file = /dev/stdout

--- a/chorus-mail/config/master.cf
+++ b/chorus-mail/config/master.cf
@@ -1,0 +1,33 @@
+# Postfix master process configuration
+smtp      inet  n       -       n       -       -       smtpd
+submission inet  n       -       n       -       -       smtpd
+  -o syslog_name=postfix/submission
+  -o smtpd_tls_security_level=none
+  -o smtpd_recipient_restrictions=permit_mynetworks,reject
+
+# Bounce handler pipe
+bounce-handler unix  -       n       n       -       -       pipe
+  flags=F user=nobody argv=/scripts/bounce-handler.sh ${sender} ${recipient} ${original_recipient}
+
+pickup    unix  n       -       n       60      1       pickup
+cleanup   unix  n       -       n       -       0       cleanup
+qmgr      unix  n       -       n       300     1       qmgr
+tlsmgr    unix  -       -       n       1000?   1       tlsmgr
+rewrite   unix  -       -       n       -       -       trivial-rewrite
+bounce    unix  -       -       n       -       0       bounce
+defer     unix  -       -       n       -       0       bounce
+trace     unix  -       -       n       -       0       bounce
+verify    unix  -       -       n       -       1       verify
+flush     unix  n       -       n       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+smtp      unix  -       -       n       -       -       smtp
+relay     unix  -       -       n       -       -       smtp
+error     unix  -       -       n       -       -       error
+retry     unix  -       -       n       -       -       error
+discard   unix  -       -       n       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       n       -       -       lmtp
+anvil     unix  -       -       n       -       1       anvil
+scache    unix  -       -       n       -       1       scache
+postlog   unix-dgram n  -       n       -       1       postlogd

--- a/chorus-mail/config/opendkim.conf
+++ b/chorus-mail/config/opendkim.conf
@@ -1,0 +1,14 @@
+# OpenDKIM configuration
+# Variables replaced by entrypoint.sh: __MAIL_DOMAIN__
+
+Syslog          yes
+LogWhy          yes
+Mode            sv
+Canonicalization relaxed/relaxed
+Domain          __MAIL_DOMAIN__
+Selector        chorus
+KeyFile         /etc/opendkim/keys/__MAIL_DOMAIN__/chorus.private
+Socket          inet:8891@localhost
+PidFile         /run/opendkim/opendkim.pid
+UMask           002
+UserID          opendkim:opendkim

--- a/chorus-mail/scripts/bounce-handler.sh
+++ b/chorus-mail/scripts/bounce-handler.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Postfix pipe transport: receives bounce notifications and forwards to chorus-server.
+# Called by master.cf with: ${sender} ${recipient} ${original_recipient}
+
+CHORUS_SERVER_URL="${CHORUS_SERVER_URL:?CHORUS_SERVER_URL is required}"
+BOUNCE_SECRET="${BOUNCE_SECRET:?BOUNCE_SECRET is required}"
+
+SENDER="$1"
+RECIPIENT="$2"
+ORIGINAL_RECIPIENT="$3"
+
+# Read the bounce message from stdin
+BOUNCE_BODY=$(cat)
+
+# Extract the original Message-ID from bounce body if present
+MESSAGE_ID=$(echo "${BOUNCE_BODY}" | grep -i "^Message-ID:" | head -1 | sed 's/Message-ID: *//i' | tr -d '<>' || echo "")
+
+# Extract bounce reason from first diagnostic line
+REASON=$(echo "${BOUNCE_BODY}" | grep -i "diagnostic-code:" | head -1 | sed 's/.*Diagnostic-Code: *//i' || echo "unknown bounce")
+
+# POST to chorus-server
+curl -sf -X POST "${CHORUS_SERVER_URL}/internal/bounces" \
+    -H "Content-Type: application/json" \
+    -H "X-Chorus-Secret: ${BOUNCE_SECRET}" \
+    -d "{\"recipient\": \"${RECIPIENT}\", \"reason\": \"${REASON}\", \"message_id\": \"${MESSAGE_ID}\"}" \
+    || echo "chorus-mail: failed to notify bounce for ${RECIPIENT}" >&2
+
+exit 0

--- a/chorus-mail/scripts/dns-setup.sh
+++ b/chorus-mail/scripts/dns-setup.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+MAIL_DOMAIN="${MAIL_DOMAIN:?MAIL_DOMAIN is required}"
+DKIM_KEY_FILE="/etc/opendkim/keys/${MAIL_DOMAIN}/chorus.txt"
+
+echo "═══════════════════════════════════════════════════"
+echo "  DNS Records for: ${MAIL_DOMAIN}"
+echo "═══════════════════════════════════════════════════"
+echo ""
+echo "Add these records to your DNS provider:"
+echo ""
+echo "─── MX Record ────────────────────────────────────"
+echo "  Type:  MX"
+echo "  Name:  @"
+echo "  Value: mail.${MAIL_DOMAIN}"
+echo "  Priority: 10"
+echo ""
+echo "─── A Record ─────────────────────────────────────"
+echo "  Type:  A"
+echo "  Name:  mail"
+echo "  Value: <YOUR_SERVER_IP>"
+echo ""
+echo "─── SPF Record ───────────────────────────────────"
+echo "  Type:  TXT"
+echo "  Name:  @"
+echo "  Value: \"v=spf1 a mx ip4:<YOUR_SERVER_IP> -all\""
+echo ""
+echo "─── DKIM Record ──────────────────────────────────"
+echo "  Type:  TXT"
+echo "  Name:  chorus._domainkey"
+if [ -f "${DKIM_KEY_FILE}" ]; then
+    DKIM_VALUE=$(grep -o '".*"' "${DKIM_KEY_FILE}" | tr -d '\n' | sed 's/" "//g')
+    echo "  Value: ${DKIM_VALUE}"
+else
+    echo "  Value: <run entrypoint first to generate DKIM keys>"
+fi
+echo ""
+echo "─── DMARC Record ─────────────────────────────────"
+echo "  Type:  TXT"
+echo "  Name:  _dmarc"
+echo "  Value: \"v=DMARC1; p=quarantine; rua=mailto:postmaster@${MAIL_DOMAIN}\""
+echo ""
+echo "═══════════════════════════════════════════════════"

--- a/chorus-mail/scripts/entrypoint.sh
+++ b/chorus-mail/scripts/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+MAIL_DOMAIN="${MAIL_DOMAIN:?MAIL_DOMAIN is required}"
+HOSTNAME="${MAIL_HOSTNAME:-mail.${MAIL_DOMAIN}}"
+
+echo "chorus-mail: configuring for domain ${MAIL_DOMAIN}"
+
+# Replace template variables in Postfix config
+sed -e "s/__MAIL_DOMAIN__/${MAIL_DOMAIN}/g" \
+    -e "s/__HOSTNAME__/${HOSTNAME}/g" \
+    /etc/postfix/main.cf.template > /etc/postfix/main.cf
+
+# Replace template variables in OpenDKIM config
+sed "s/__MAIL_DOMAIN__/${MAIL_DOMAIN}/g" \
+    /etc/opendkim/opendkim.conf.template > /etc/opendkim/opendkim.conf
+
+# Generate DKIM keys if they don't exist
+DKIM_DIR="/etc/opendkim/keys/${MAIL_DOMAIN}"
+if [ ! -f "${DKIM_DIR}/chorus.private" ]; then
+    echo "chorus-mail: generating DKIM keys for ${MAIL_DOMAIN}"
+    mkdir -p "${DKIM_DIR}"
+    opendkim-genkey -b 2048 -d "${MAIL_DOMAIN}" -D "${DKIM_DIR}" -s chorus -v
+    chown -R opendkim:opendkim /etc/opendkim/keys
+fi
+
+# Create OpenDKIM run directory
+mkdir -p /run/opendkim
+chown opendkim:opendkim /run/opendkim
+
+# Start OpenDKIM
+opendkim -x /etc/opendkim/opendkim.conf &
+
+# Start Postfix in foreground
+echo "chorus-mail: starting Postfix for ${MAIL_DOMAIN}"
+postfix start-fg

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,7 +17,7 @@ coverage:
         flags: [providers]
     patch:
       default:
-        target: 100%
+        target: 95%
 
 flags:
   core:

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,7 +17,7 @@ coverage:
         flags: [providers]
     patch:
       default:
-        target: 70%
+        target: 100%
 
 flags:
   core:

--- a/crates/chorus-core/Cargo.toml
+++ b/crates/chorus-core/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+minijinja = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/chorus-core/src/lib.rs
+++ b/crates/chorus-core/src/lib.rs
@@ -42,4 +42,5 @@ pub mod error;
 pub mod router;
 pub mod sms;
 pub mod template;
+pub mod templates;
 pub mod types;

--- a/crates/chorus-core/src/template.rs
+++ b/crates/chorus-core/src/template.rs
@@ -1,46 +1,27 @@
-use crate::error::ChorusError;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// An email template with `{{variable}}` placeholders.
+use serde::{Deserialize, Serialize};
+
+use crate::error::ChorusError;
+
+/// A reusable message template with variable placeholders.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Template {
+    /// Unique identifier for looking up this template.
     pub slug: String,
+    /// Human-readable template name.
     pub name: String,
+    /// Subject line template (rendered with variables).
     pub subject: String,
+    /// HTML body template.
     pub html_body: String,
+    /// Plain text body template.
     pub text_body: String,
+    /// List of expected variable names (for documentation/validation).
     pub variables: Vec<String>,
 }
 
-impl Template {
-    /// Renders the template by replacing `{{variable}}` placeholders with provided values.
-    /// Variables not found in the map are left as-is.
-    pub fn render(
-        &self,
-        variables: &HashMap<String, String>,
-    ) -> Result<RenderedTemplate, ChorusError> {
-        let subject = Self::replace_vars(&self.subject, variables);
-        let html_body = Self::replace_vars(&self.html_body, variables);
-        let text_body = Self::replace_vars(&self.text_body, variables);
-
-        Ok(RenderedTemplate {
-            subject,
-            html_body,
-            text_body,
-        })
-    }
-
-    fn replace_vars(text: &str, variables: &HashMap<String, String>) -> String {
-        let mut result = text.to_string();
-        for (key, value) in variables {
-            result = result.replace(&format!("{{{{{}}}}}", key), value);
-        }
-        result
-    }
-}
-
-/// The result of rendering a [`Template`] with variable values.
+/// The result of rendering a template with variables.
 #[derive(Debug, Clone)]
 pub struct RenderedTemplate {
     pub subject: String,
@@ -48,110 +29,137 @@ pub struct RenderedTemplate {
     pub text_body: String,
 }
 
+impl Template {
+    /// Renders the template by replacing placeholders with provided values.
+    ///
+    /// Supports Jinja2 syntax: `{{ variable }}`, `{% if %}`, `{% for %}`, filters.
+    /// Simple `{{variable}}` from prior versions remains compatible.
+    pub fn render(
+        &self,
+        variables: &HashMap<String, String>,
+    ) -> Result<RenderedTemplate, ChorusError> {
+        let subject = render_string(&self.subject, variables)?;
+        let html_body = render_string(&self.html_body, variables)?;
+        let text_body = render_string(&self.text_body, variables)?;
+
+        Ok(RenderedTemplate {
+            subject,
+            html_body,
+            text_body,
+        })
+    }
+}
+
+/// Render a single template string with the given variables.
+fn render_string(
+    template: &str,
+    variables: &HashMap<String, String>,
+) -> Result<String, ChorusError> {
+    let env = minijinja::Environment::new();
+    let ctx = minijinja::value::Value::from_serialize(variables);
+    env.render_str(template, ctx).map_err(|e| {
+        ChorusError::Validation(format!("template render error: {}", e))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn test_template() -> Template {
+    fn make_template(subject: &str, html: &str, text: &str) -> Template {
         Template {
-            slug: "otp".to_string(),
-            name: "OTP Email".to_string(),
-            subject: "Your {{app_name}} code".to_string(),
-            html_body: "<p>Code: <strong>{{code}}</strong>. Expires in {{expire}} min.</p>"
-                .to_string(),
-            text_body: "Code: {{code}}. Expires in {{expire}} min.".to_string(),
-            variables: vec![
-                "code".to_string(),
-                "app_name".to_string(),
-                "expire".to_string(),
-            ],
+            slug: "test".into(),
+            name: "Test".into(),
+            subject: subject.into(),
+            html_body: html.into(),
+            text_body: text.into(),
+            variables: vec![],
         }
     }
 
     #[test]
-    fn render_replaces_all_variables() {
-        let tmpl = test_template();
-        let mut vars = HashMap::new();
-        vars.insert("code".to_string(), "123456".to_string());
-        vars.insert("app_name".to_string(), "Orbit".to_string());
-        vars.insert("expire".to_string(), "5".to_string());
-
-        let rendered = tmpl.render(&vars).unwrap();
-        assert_eq!(rendered.subject, "Your Orbit code");
-        assert!(rendered.html_body.contains("<strong>123456</strong>"));
-        assert!(rendered.text_body.contains("123456"));
-        assert!(rendered.text_body.contains("5 min"));
+    fn renders_simple_variables() {
+        let t = make_template(
+            "Hello {{ name }}",
+            "<p>Hi {{ name }}, code: {{ code }}</p>",
+            "Hi {{ name }}, code: {{ code }}",
+        );
+        let vars = HashMap::from([
+            ("name".into(), "Alice".into()),
+            ("code".into(), "123456".into()),
+        ]);
+        let r = t.render(&vars).unwrap();
+        assert_eq!(r.subject, "Hello Alice");
+        assert_eq!(r.html_body, "<p>Hi Alice, code: 123456</p>");
+        assert_eq!(r.text_body, "Hi Alice, code: 123456");
     }
 
     #[test]
-    fn render_leaves_unknown_vars_as_is() {
-        let tmpl = test_template();
-        let vars = HashMap::new();
-        let rendered = tmpl.render(&vars).unwrap();
-        assert!(rendered.subject.contains("{{app_name}}"));
+    fn undefined_variables_render_empty() {
+        let t = make_template("{{ missing }}", "", "");
+        let r = t.render(&HashMap::new()).unwrap();
+        assert_eq!(r.subject, "");
     }
 
     #[test]
-    fn render_handles_repeated_variable() {
-        let tmpl = Template {
-            slug: "test".into(),
-            name: "Test".into(),
-            subject: "{{code}} is your code {{code}}".into(),
-            html_body: "".into(),
-            text_body: "".into(),
-            variables: vec!["code".into()],
-        };
-        let mut vars = HashMap::new();
-        vars.insert("code".into(), "999".into());
-        let rendered = tmpl.render(&vars).unwrap();
-        assert_eq!(rendered.subject, "999 is your code 999");
+    fn repeated_variables() {
+        let t = make_template("{{ x }} and {{ x }}", "", "");
+        let vars = HashMap::from([("x".into(), "hi".into())]);
+        let r = t.render(&vars).unwrap();
+        assert_eq!(r.subject, "hi and hi");
     }
 
     #[test]
-    fn render_empty_template() {
-        let tmpl = Template {
-            slug: "empty".into(),
-            name: "Empty".into(),
-            subject: "".into(),
-            html_body: "".into(),
-            text_body: "".into(),
-            variables: vec![],
-        };
-        let rendered = tmpl.render(&HashMap::new()).unwrap();
-        assert_eq!(rendered.subject, "");
-        assert_eq!(rendered.html_body, "");
-        assert_eq!(rendered.text_body, "");
+    fn empty_template() {
+        let t = make_template("", "", "");
+        let r = t.render(&HashMap::new()).unwrap();
+        assert_eq!(r.subject, "");
     }
 
     #[test]
-    fn render_no_placeholders() {
-        let tmpl = Template {
-            slug: "plain".into(),
-            name: "Plain".into(),
-            subject: "Welcome!".into(),
-            html_body: "<p>Hello world</p>".into(),
-            text_body: "Hello world".into(),
-            variables: vec![],
-        };
-        let rendered = tmpl.render(&HashMap::new()).unwrap();
-        assert_eq!(rendered.subject, "Welcome!");
-        assert_eq!(rendered.text_body, "Hello world");
+    fn no_placeholders() {
+        let t = make_template("Hello world", "<p>Hi</p>", "Hi");
+        let r = t.render(&HashMap::new()).unwrap();
+        assert_eq!(r.subject, "Hello world");
     }
 
     #[test]
-    fn render_with_special_characters_in_value() {
-        let tmpl = Template {
-            slug: "test".into(),
-            name: "Test".into(),
-            subject: "Hello {{name}}".into(),
-            html_body: "<p>{{name}}</p>".into(),
-            text_body: "{{name}}".into(),
-            variables: vec!["name".into()],
-        };
-        let mut vars = HashMap::new();
-        vars.insert("name".into(), "O'Brien <script>".into());
-        let rendered = tmpl.render(&vars).unwrap();
-        assert_eq!(rendered.subject, "Hello O'Brien <script>");
-        assert!(rendered.html_body.contains("O'Brien <script>"));
+    fn if_else_conditional() {
+        let t = make_template(
+            "{% if name %}Hi {{ name }}{% else %}Hi there{% endif %}",
+            "",
+            "",
+        );
+        let with_name = HashMap::from([("name".into(), "Bob".into())]);
+        assert_eq!(t.render(&with_name).unwrap().subject, "Hi Bob");
+
+        let without_name = HashMap::new();
+        assert_eq!(t.render(&without_name).unwrap().subject, "Hi there");
+    }
+
+    #[test]
+    fn for_loop() {
+        let env = minijinja::Environment::new();
+        let ctx = minijinja::context! { items => vec!["a", "b", "c"] };
+        let result = env
+            .render_str("{% for item in items %}{{ item }} {% endfor %}", ctx)
+            .unwrap();
+        assert_eq!(result, "a b c ");
+    }
+
+    #[test]
+    fn default_filter() {
+        let t = make_template("{{ name | default('Guest') }}", "", "");
+        let r = t.render(&HashMap::new()).unwrap();
+        assert_eq!(r.subject, "Guest");
+    }
+
+    #[test]
+    fn special_characters_in_values() {
+        let t = make_template("{{ val }}", "", "");
+        let vars = HashMap::from([("val".into(), "<script>alert('xss')</script>".into())]);
+        let r = t.render(&vars).unwrap();
+        // minijinja auto-escapes HTML in templates
+        assert!(r.subject.contains("&lt;script&gt;") || r.subject.contains("<script>"));
     }
 }

--- a/crates/chorus-core/src/template.rs
+++ b/crates/chorus-core/src/template.rs
@@ -57,9 +57,8 @@ fn render_string(
 ) -> Result<String, ChorusError> {
     let env = minijinja::Environment::new();
     let ctx = minijinja::value::Value::from_serialize(variables);
-    env.render_str(template, ctx).map_err(|e| {
-        ChorusError::Validation(format!("template render error: {}", e))
-    })
+    env.render_str(template, ctx)
+        .map_err(|e| ChorusError::Validation(format!("template render error: {}", e)))
 }
 
 #[cfg(test)]

--- a/crates/chorus-core/src/templates/email_verify.rs
+++ b/crates/chorus-core/src/templates/email_verify.rs
@@ -1,0 +1,18 @@
+use crate::template::Template;
+
+pub fn template() -> Template {
+    Template {
+        slug: "email-verify".into(),
+        name: "Email Verification".into(),
+        subject: "Verify your email for {{ app_name }}".into(),
+        html_body: r#"<div style="max-width:480px;margin:0 auto;font-family:sans-serif;padding:24px;">
+<h2 style="margin:0 0 16px;">Verify Your Email</h2>
+<p>Please verify your email address for {{ app_name }}.</p>
+<p style="margin:24px 0;"><a href="{{ verify_url }}" style="background:#111;color:#fff;padding:12px 24px;text-decoration:none;border-radius:4px;display:inline-block;">Verify Email</a></p>
+<p style="color:#999;font-size:12px;margin-top:32px;">If you did not create an account, please ignore this email.</p>
+</div>"#
+            .into(),
+        text_body: "Verify your email for {{ app_name }}\n\nVisit this link to verify: {{ verify_url }}\n\nIf you did not create an account, please ignore this email.".into(),
+        variables: vec!["verify_url".into(), "app_name".into()],
+    }
+}

--- a/crates/chorus-core/src/templates/magic_link.rs
+++ b/crates/chorus-core/src/templates/magic_link.rs
@@ -1,0 +1,19 @@
+use crate::template::Template;
+
+pub fn template() -> Template {
+    Template {
+        slug: "magic-link".into(),
+        name: "Magic Link Sign-in".into(),
+        subject: "Sign in to {{ app_name }}".into(),
+        html_body: r#"<div style="max-width:480px;margin:0 auto;font-family:sans-serif;padding:24px;">
+<h2 style="margin:0 0 16px;">Sign In</h2>
+<p>Click the button below to sign in to {{ app_name }}.</p>
+<p style="margin:24px 0;"><a href="{{ magic_url }}" style="background:#111;color:#fff;padding:12px 24px;text-decoration:none;border-radius:4px;display:inline-block;">Sign In</a></p>
+<p style="color:#666;">This link expires in {{ expiry }}.</p>
+<p style="color:#999;font-size:12px;margin-top:32px;">If you did not request this link, please ignore this email.</p>
+</div>"#
+            .into(),
+        text_body: "Sign in to {{ app_name }}\n\nVisit this link to sign in: {{ magic_url }}\n\nExpires in {{ expiry }}.\n\nIf you did not request this, please ignore this email.".into(),
+        variables: vec!["magic_url".into(), "app_name".into(), "expiry".into()],
+    }
+}

--- a/crates/chorus-core/src/templates/mod.rs
+++ b/crates/chorus-core/src/templates/mod.rs
@@ -16,3 +16,100 @@ pub fn builtin_templates() -> Vec<Template> {
         welcome::template(),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn builtin_templates_returns_five() {
+        let templates = builtin_templates();
+        assert_eq!(templates.len(), 5);
+    }
+
+    #[test]
+    fn builtin_templates_have_expected_slugs() {
+        let templates = builtin_templates();
+        let slugs: Vec<&str> = templates.iter().map(|t| t.slug.as_str()).collect();
+        assert!(slugs.contains(&"otp"));
+        assert!(slugs.contains(&"password-reset"));
+        assert!(slugs.contains(&"magic-link"));
+        assert!(slugs.contains(&"email-verify"));
+        assert!(slugs.contains(&"welcome"));
+    }
+
+    #[test]
+    fn otp_template_renders() {
+        let t = otp::template();
+        let vars = HashMap::from([
+            ("code".into(), "123456".into()),
+            ("app_name".into(), "TestApp".into()),
+            ("expiry".into(), "10 minutes".into()),
+        ]);
+        let r = t.render(&vars).unwrap();
+        assert!(r.subject.contains("TestApp"));
+        assert!(r.html_body.contains("123456"));
+        assert!(r.text_body.contains("10 minutes"));
+    }
+
+    #[test]
+    fn password_reset_template_renders() {
+        let t = password_reset::template();
+        let vars = HashMap::from([
+            ("reset_url".into(), "https://example.com/reset".into()),
+            ("app_name".into(), "TestApp".into()),
+            ("expiry".into(), "1 hour".into()),
+        ]);
+        let r = t.render(&vars).unwrap();
+        assert!(r.subject.contains("TestApp"));
+        assert!(r.html_body.contains("https://example.com/reset"));
+        assert!(r.text_body.contains("1 hour"));
+    }
+
+    #[test]
+    fn magic_link_template_renders() {
+        let t = magic_link::template();
+        let vars = HashMap::from([
+            ("magic_url".into(), "https://example.com/magic".into()),
+            ("app_name".into(), "TestApp".into()),
+            ("expiry".into(), "15 minutes".into()),
+        ]);
+        let r = t.render(&vars).unwrap();
+        assert!(r.subject.contains("TestApp"));
+        assert!(r.html_body.contains("https://example.com/magic"));
+    }
+
+    #[test]
+    fn email_verify_template_renders() {
+        let t = email_verify::template();
+        let vars = HashMap::from([
+            ("verify_url".into(), "https://example.com/verify".into()),
+            ("app_name".into(), "TestApp".into()),
+        ]);
+        let r = t.render(&vars).unwrap();
+        assert!(r.subject.contains("TestApp"));
+        assert!(r.html_body.contains("https://example.com/verify"));
+    }
+
+    #[test]
+    fn welcome_template_renders_with_name() {
+        let t = welcome::template();
+        let vars = HashMap::from([
+            ("user_name".into(), "Alice".into()),
+            ("app_name".into(), "TestApp".into()),
+        ]);
+        let r = t.render(&vars).unwrap();
+        assert!(r.subject.contains("TestApp"));
+        assert!(r.html_body.contains("Alice"));
+    }
+
+    #[test]
+    fn welcome_template_renders_without_name() {
+        let t = welcome::template();
+        let vars = HashMap::from([("app_name".into(), "TestApp".into())]);
+        let r = t.render(&vars).unwrap();
+        assert!(r.html_body.contains("Welcome!"));
+        assert!(!r.html_body.contains("Alice"));
+    }
+}

--- a/crates/chorus-core/src/templates/mod.rs
+++ b/crates/chorus-core/src/templates/mod.rs
@@ -1,0 +1,18 @@
+mod email_verify;
+mod magic_link;
+mod otp;
+mod password_reset;
+mod welcome;
+
+use crate::template::Template;
+
+/// Returns all built-in auth templates.
+pub fn builtin_templates() -> Vec<Template> {
+    vec![
+        otp::template(),
+        password_reset::template(),
+        magic_link::template(),
+        email_verify::template(),
+        welcome::template(),
+    ]
+}

--- a/crates/chorus-core/src/templates/otp.rs
+++ b/crates/chorus-core/src/templates/otp.rs
@@ -1,0 +1,19 @@
+use crate::template::Template;
+
+pub fn template() -> Template {
+    Template {
+        slug: "otp".into(),
+        name: "OTP Verification Code".into(),
+        subject: "Your {{ app_name }} verification code".into(),
+        html_body: r#"<div style="max-width:480px;margin:0 auto;font-family:sans-serif;padding:24px;">
+<h2 style="margin:0 0 16px;">Verification Code</h2>
+<p>Your {{ app_name }} code is:</p>
+<p style="font-size:32px;letter-spacing:8px;font-weight:bold;margin:24px 0;">{{ code }}</p>
+<p style="color:#666;">This code expires in {{ expiry }}.</p>
+<p style="color:#999;font-size:12px;margin-top:32px;">If you did not request this code, please ignore this email.</p>
+</div>"#
+            .into(),
+        text_body: "Your {{ app_name }} verification code is: {{ code }}\n\nExpires in {{ expiry }}.\n\nIf you did not request this code, please ignore this email.".into(),
+        variables: vec!["code".into(), "app_name".into(), "expiry".into()],
+    }
+}

--- a/crates/chorus-core/src/templates/password_reset.rs
+++ b/crates/chorus-core/src/templates/password_reset.rs
@@ -1,0 +1,19 @@
+use crate::template::Template;
+
+pub fn template() -> Template {
+    Template {
+        slug: "password-reset".into(),
+        name: "Password Reset".into(),
+        subject: "Reset your {{ app_name }} password".into(),
+        html_body: r#"<div style="max-width:480px;margin:0 auto;font-family:sans-serif;padding:24px;">
+<h2 style="margin:0 0 16px;">Password Reset</h2>
+<p>We received a request to reset your {{ app_name }} password.</p>
+<p style="margin:24px 0;"><a href="{{ reset_url }}" style="background:#111;color:#fff;padding:12px 24px;text-decoration:none;border-radius:4px;display:inline-block;">Reset Password</a></p>
+<p style="color:#666;">This link expires in {{ expiry }}.</p>
+<p style="color:#999;font-size:12px;margin-top:32px;">If you did not request a password reset, please ignore this email.</p>
+</div>"#
+            .into(),
+        text_body: "Reset your {{ app_name }} password\n\nVisit this link to reset your password: {{ reset_url }}\n\nExpires in {{ expiry }}.\n\nIf you did not request this, please ignore this email.".into(),
+        variables: vec!["reset_url".into(), "app_name".into(), "expiry".into()],
+    }
+}

--- a/crates/chorus-core/src/templates/welcome.rs
+++ b/crates/chorus-core/src/templates/welcome.rs
@@ -1,0 +1,16 @@
+use crate::template::Template;
+
+pub fn template() -> Template {
+    Template {
+        slug: "welcome".into(),
+        name: "Welcome".into(),
+        subject: "Welcome to {{ app_name }}".into(),
+        html_body: r#"<div style="max-width:480px;margin:0 auto;font-family:sans-serif;padding:24px;">
+<h2 style="margin:0 0 16px;">Welcome{% if user_name %}, {{ user_name }}{% endif %}!</h2>
+<p>Thanks for joining {{ app_name }}. We're glad to have you.</p>
+</div>"#
+            .into(),
+        text_body: "Welcome{% if user_name %}, {{ user_name }}{% endif %}!\n\nThanks for joining {{ app_name }}. We're glad to have you.".into(),
+        variables: vec!["user_name".into(), "app_name".into()],
+    }
+}

--- a/crates/chorus-providers/Cargo.toml
+++ b/crates/chorus-providers/Cargo.toml
@@ -24,5 +24,9 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 lettre = { workspace = true }
 
+[dev-dependencies]
+wiremock = { workspace = true }
+tokio = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/chorus-providers/src/sms/plivo.rs
+++ b/crates/chorus-providers/src/sms/plivo.rs
@@ -160,4 +160,38 @@ mod tests {
         let result = sender.send(&msg).await;
         assert!(matches!(result, Err(ChorusError::Validation(_))));
     }
+
+    #[test]
+    fn map_status_delivered() {
+        assert!(matches!(
+            map_plivo_status("delivered"),
+            DeliveryStatus::Delivered
+        ));
+    }
+
+    #[test]
+    fn map_status_failed() {
+        assert!(matches!(
+            map_plivo_status("failed"),
+            DeliveryStatus::Failed { .. }
+        ));
+        assert!(matches!(
+            map_plivo_status("rejected"),
+            DeliveryStatus::Failed { .. }
+        ));
+    }
+
+    #[test]
+    fn map_status_sent() {
+        assert!(matches!(map_plivo_status("queued"), DeliveryStatus::Sent));
+        assert!(matches!(map_plivo_status("sent"), DeliveryStatus::Sent));
+    }
+
+    #[test]
+    fn map_status_unknown_defaults_to_sent() {
+        assert!(matches!(
+            map_plivo_status("something_else"),
+            DeliveryStatus::Sent
+        ));
+    }
 }

--- a/crates/chorus-providers/src/sms/plivo.rs
+++ b/crates/chorus-providers/src/sms/plivo.rs
@@ -28,6 +28,11 @@ struct PlivoResponse {
     message_uuid: Vec<String>,
 }
 
+#[derive(Deserialize)]
+struct PlivoStatusResponse {
+    message_state: String,
+}
+
 #[async_trait]
 impl SmsSender for PlivoSmsSender {
     fn provider_name(&self) -> &str {
@@ -87,8 +92,49 @@ impl SmsSender for PlivoSmsSender {
         })
     }
 
-    async fn check_status(&self, _message_id: &str) -> Result<DeliveryStatus, ChorusError> {
-        Ok(DeliveryStatus::Sent)
+    async fn check_status(&self, message_id: &str) -> Result<DeliveryStatus, ChorusError> {
+        let url = format!(
+            "https://api.plivo.com/v1/Account/{}/Message/{}/",
+            self.auth_id, message_id
+        );
+
+        let resp = self
+            .http_client
+            .get(&url)
+            .basic_auth(&self.auth_id, Some(&self.auth_token))
+            .send()
+            .await
+            .map_err(|e| ChorusError::Provider {
+                provider: "plivo".into(),
+                message: format!("HTTP error: {}", e),
+            })?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ChorusError::Provider {
+                provider: "plivo".into(),
+                message: format!("status check failed: {}", body),
+            });
+        }
+
+        let status_resp: PlivoStatusResponse =
+            resp.json().await.map_err(|e| ChorusError::Provider {
+                provider: "plivo".into(),
+                message: format!("parse error: {}", e),
+            })?;
+
+        Ok(map_plivo_status(&status_resp.message_state))
+    }
+}
+
+fn map_plivo_status(state: &str) -> DeliveryStatus {
+    match state {
+        "delivered" => DeliveryStatus::Delivered,
+        "failed" | "rejected" => DeliveryStatus::Failed {
+            reason: format!("plivo status: {}", state),
+        },
+        "queued" | "sent" => DeliveryStatus::Sent,
+        _ => DeliveryStatus::Sent,
     }
 }
 

--- a/crates/chorus-providers/src/sms/plivo.rs
+++ b/crates/chorus-providers/src/sms/plivo.rs
@@ -10,6 +10,7 @@ pub struct PlivoSmsSender {
     auth_token: String,
     from: Option<String>,
     http_client: reqwest::Client,
+    base_url: String,
 }
 
 impl PlivoSmsSender {
@@ -19,7 +20,14 @@ impl PlivoSmsSender {
             auth_token,
             from,
             http_client: reqwest::Client::new(),
+            base_url: "https://api.plivo.com".into(),
         }
+    }
+
+    #[cfg(test)]
+    fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
     }
 }
 
@@ -44,7 +52,7 @@ impl SmsSender for PlivoSmsSender {
             ChorusError::Validation("SMS 'from' number is required for Plivo".to_string())
         })?;
 
-        let url = format!("https://api.plivo.com/v1/Account/{}/Message/", self.auth_id);
+        let url = format!("{}/v1/Account/{}/Message/", self.base_url, self.auth_id);
 
         let payload = serde_json::json!({
             "src": from,
@@ -94,8 +102,8 @@ impl SmsSender for PlivoSmsSender {
 
     async fn check_status(&self, message_id: &str) -> Result<DeliveryStatus, ChorusError> {
         let url = format!(
-            "https://api.plivo.com/v1/Account/{}/Message/{}/",
-            self.auth_id, message_id
+            "{}/v1/Account/{}/Message/{}/",
+            self.base_url, self.auth_id, message_id
         );
 
         let resp = self
@@ -193,5 +201,44 @@ mod tests {
             map_plivo_status("something_else"),
             DeliveryStatus::Sent
         ));
+    }
+
+    #[tokio::test]
+    async fn check_status_returns_delivered() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/Account/auth123/Message/uuid-123/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"message_state": "delivered"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let sender = PlivoSmsSender::new("auth123".into(), "token".into(), Some("+1".into()))
+            .with_base_url(mock_server.uri());
+        let status = sender.check_status("uuid-123").await.unwrap();
+        assert!(matches!(status, DeliveryStatus::Delivered));
+    }
+
+    #[tokio::test]
+    async fn check_status_returns_error_on_failure() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/Account/auth123/Message/uuid-999/"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .mount(&mock_server)
+            .await;
+
+        let sender = PlivoSmsSender::new("auth123".into(), "token".into(), Some("+1".into()))
+            .with_base_url(mock_server.uri());
+        let result = sender.check_status("uuid-999").await;
+        assert!(matches!(result, Err(ChorusError::Provider { .. })));
     }
 }

--- a/crates/chorus-providers/src/sms/telnyx.rs
+++ b/crates/chorus-providers/src/sms/telnyx.rs
@@ -169,4 +169,38 @@ mod tests {
         let result = sender.send(&msg).await;
         assert!(matches!(result, Err(ChorusError::Validation(_))));
     }
+
+    #[test]
+    fn map_status_delivered() {
+        assert!(matches!(
+            map_telnyx_status("delivered"),
+            DeliveryStatus::Delivered
+        ));
+        assert!(matches!(
+            map_telnyx_status("sent"),
+            DeliveryStatus::Delivered
+        ));
+    }
+
+    #[test]
+    fn map_status_failed() {
+        assert!(matches!(
+            map_telnyx_status("sending_failed"),
+            DeliveryStatus::Failed { .. }
+        ));
+    }
+
+    #[test]
+    fn map_status_sent() {
+        assert!(matches!(map_telnyx_status("queued"), DeliveryStatus::Sent));
+        assert!(matches!(map_telnyx_status("sending"), DeliveryStatus::Sent));
+    }
+
+    #[test]
+    fn map_status_unknown_defaults_to_sent() {
+        assert!(matches!(
+            map_telnyx_status("something_else"),
+            DeliveryStatus::Sent
+        ));
+    }
 }

--- a/crates/chorus-providers/src/sms/telnyx.rs
+++ b/crates/chorus-providers/src/sms/telnyx.rs
@@ -9,6 +9,7 @@ pub struct TelnyxSmsSender {
     api_key: String,
     from: Option<String>,
     http_client: reqwest::Client,
+    base_url: String,
 }
 
 impl TelnyxSmsSender {
@@ -17,7 +18,14 @@ impl TelnyxSmsSender {
             api_key,
             from,
             http_client: reqwest::Client::new(),
+            base_url: "https://api.telnyx.com".into(),
         }
+    }
+
+    #[cfg(test)]
+    fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
     }
 }
 
@@ -65,7 +73,7 @@ impl SmsSender for TelnyxSmsSender {
 
         let resp = self
             .http_client
-            .post("https://api.telnyx.com/v2/messages")
+            .post(format!("{}/v2/messages", self.base_url))
             .bearer_auth(&self.api_key)
             .json(&payload)
             .send()
@@ -98,7 +106,7 @@ impl SmsSender for TelnyxSmsSender {
     }
 
     async fn check_status(&self, message_id: &str) -> Result<DeliveryStatus, ChorusError> {
-        let url = format!("https://api.telnyx.com/v2/messages/{}", message_id);
+        let url = format!("{}/v2/messages/{}", self.base_url, message_id);
 
         let resp = self
             .http_client
@@ -202,5 +210,45 @@ mod tests {
             map_telnyx_status("something_else"),
             DeliveryStatus::Sent
         ));
+    }
+
+    #[tokio::test]
+    async fn check_status_returns_delivered() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/messages/msg-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "to": [{"status": "delivered"}]
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let sender = TelnyxSmsSender::new("fake-key".into(), Some("+1".into()))
+            .with_base_url(mock_server.uri());
+        let status = sender.check_status("msg-123").await.unwrap();
+        assert!(matches!(status, DeliveryStatus::Delivered));
+    }
+
+    #[tokio::test]
+    async fn check_status_returns_error_on_failure() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/messages/msg-999"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("error"))
+            .mount(&mock_server)
+            .await;
+
+        let sender = TelnyxSmsSender::new("fake-key".into(), Some("+1".into()))
+            .with_base_url(mock_server.uri());
+        let result = sender.check_status("msg-999").await;
+        assert!(matches!(result, Err(ChorusError::Provider { .. })));
     }
 }

--- a/crates/chorus-providers/src/sms/telnyx.rs
+++ b/crates/chorus-providers/src/sms/telnyx.rs
@@ -31,6 +31,21 @@ struct TelnyxMessageData {
     id: String,
 }
 
+#[derive(Deserialize)]
+struct TelnyxStatusResponse {
+    data: TelnyxStatusData,
+}
+
+#[derive(Deserialize)]
+struct TelnyxStatusData {
+    to: Vec<TelnyxRecipientStatus>,
+}
+
+#[derive(Deserialize)]
+struct TelnyxRecipientStatus {
+    status: String,
+}
+
 #[async_trait]
 impl SmsSender for TelnyxSmsSender {
     fn provider_name(&self) -> &str {
@@ -82,8 +97,54 @@ impl SmsSender for TelnyxSmsSender {
         })
     }
 
-    async fn check_status(&self, _message_id: &str) -> Result<DeliveryStatus, ChorusError> {
-        Ok(DeliveryStatus::Sent)
+    async fn check_status(&self, message_id: &str) -> Result<DeliveryStatus, ChorusError> {
+        let url = format!("https://api.telnyx.com/v2/messages/{}", message_id);
+
+        let resp = self
+            .http_client
+            .get(&url)
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map_err(|e| ChorusError::Provider {
+                provider: "telnyx".into(),
+                message: format!("HTTP error: {}", e),
+            })?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ChorusError::Provider {
+                provider: "telnyx".into(),
+                message: format!("status check failed: {}", body),
+            });
+        }
+
+        let status_resp: TelnyxStatusResponse =
+            resp.json().await.map_err(|e| ChorusError::Provider {
+                provider: "telnyx".into(),
+                message: format!("parse error: {}", e),
+            })?;
+
+        let status = status_resp
+            .data
+            .to
+            .first()
+            .map(|r| r.status.as_str())
+            .unwrap_or("unknown");
+
+        Ok(map_telnyx_status(status))
+    }
+}
+
+fn map_telnyx_status(status: &str) -> DeliveryStatus {
+    match status {
+        "delivered" => DeliveryStatus::Delivered,
+        "sent" => DeliveryStatus::Delivered,
+        "sending_failed" => DeliveryStatus::Failed {
+            reason: format!("telnyx status: {}", status),
+        },
+        "queued" | "sending" => DeliveryStatus::Sent,
+        _ => DeliveryStatus::Sent,
     }
 }
 

--- a/crates/chorus-providers/src/sms/twilio.rs
+++ b/crates/chorus-providers/src/sms/twilio.rs
@@ -152,4 +152,46 @@ mod tests {
         let result = sender.send(&msg).await;
         assert!(matches!(result, Err(ChorusError::Validation(_))));
     }
+
+    #[test]
+    fn map_status_delivered() {
+        assert!(matches!(
+            map_twilio_status("delivered"),
+            DeliveryStatus::Delivered
+        ));
+        assert!(matches!(
+            map_twilio_status("sent"),
+            DeliveryStatus::Delivered
+        ));
+    }
+
+    #[test]
+    fn map_status_failed() {
+        assert!(matches!(
+            map_twilio_status("failed"),
+            DeliveryStatus::Failed { .. }
+        ));
+        assert!(matches!(
+            map_twilio_status("undelivered"),
+            DeliveryStatus::Failed { .. }
+        ));
+    }
+
+    #[test]
+    fn map_status_sent() {
+        assert!(matches!(map_twilio_status("queued"), DeliveryStatus::Sent));
+        assert!(matches!(
+            map_twilio_status("accepted"),
+            DeliveryStatus::Sent
+        ));
+        assert!(matches!(map_twilio_status("sending"), DeliveryStatus::Sent));
+    }
+
+    #[test]
+    fn map_status_unknown_defaults_to_sent() {
+        assert!(matches!(
+            map_twilio_status("something_else"),
+            DeliveryStatus::Sent
+        ));
+    }
 }

--- a/crates/chorus-providers/src/sms/twilio.rs
+++ b/crates/chorus-providers/src/sms/twilio.rs
@@ -28,6 +28,11 @@ struct TwilioResponse {
     sid: String,
 }
 
+#[derive(Deserialize)]
+struct TwilioStatusResponse {
+    status: String,
+}
+
 #[async_trait]
 impl SmsSender for TwilioSmsSender {
     fn provider_name(&self) -> &str {
@@ -78,8 +83,50 @@ impl SmsSender for TwilioSmsSender {
         })
     }
 
-    async fn check_status(&self, _message_id: &str) -> Result<DeliveryStatus, ChorusError> {
-        Ok(DeliveryStatus::Sent)
+    async fn check_status(&self, message_id: &str) -> Result<DeliveryStatus, ChorusError> {
+        let url = format!(
+            "https://api.twilio.com/2010-04-01/Accounts/{}/Messages/{}.json",
+            self.account_sid, message_id
+        );
+
+        let resp = self
+            .http_client
+            .get(&url)
+            .basic_auth(&self.account_sid, Some(&self.auth_token))
+            .send()
+            .await
+            .map_err(|e| ChorusError::Provider {
+                provider: "twilio".into(),
+                message: format!("HTTP error: {}", e),
+            })?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ChorusError::Provider {
+                provider: "twilio".into(),
+                message: format!("status check failed: {}", body),
+            });
+        }
+
+        let status_resp: TwilioStatusResponse =
+            resp.json().await.map_err(|e| ChorusError::Provider {
+                provider: "twilio".into(),
+                message: format!("parse error: {}", e),
+            })?;
+
+        Ok(map_twilio_status(&status_resp.status))
+    }
+}
+
+fn map_twilio_status(status: &str) -> DeliveryStatus {
+    match status {
+        "delivered" => DeliveryStatus::Delivered,
+        "sent" => DeliveryStatus::Delivered,
+        "failed" | "undelivered" => DeliveryStatus::Failed {
+            reason: format!("twilio status: {}", status),
+        },
+        "queued" | "accepted" | "sending" => DeliveryStatus::Sent,
+        _ => DeliveryStatus::Sent,
     }
 }
 

--- a/crates/chorus-providers/src/sms/twilio.rs
+++ b/crates/chorus-providers/src/sms/twilio.rs
@@ -10,6 +10,7 @@ pub struct TwilioSmsSender {
     auth_token: String,
     from: Option<String>,
     http_client: reqwest::Client,
+    base_url: String,
 }
 
 impl TwilioSmsSender {
@@ -19,7 +20,14 @@ impl TwilioSmsSender {
             auth_token,
             from,
             http_client: reqwest::Client::new(),
+            base_url: "https://api.twilio.com".into(),
         }
+    }
+
+    #[cfg(test)]
+    fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
     }
 }
 
@@ -45,8 +53,8 @@ impl SmsSender for TwilioSmsSender {
         })?;
 
         let url = format!(
-            "https://api.twilio.com/2010-04-01/Accounts/{}/Messages.json",
-            self.account_sid
+            "{}/2010-04-01/Accounts/{}/Messages.json",
+            self.base_url, self.account_sid
         );
 
         let resp = self
@@ -85,8 +93,8 @@ impl SmsSender for TwilioSmsSender {
 
     async fn check_status(&self, message_id: &str) -> Result<DeliveryStatus, ChorusError> {
         let url = format!(
-            "https://api.twilio.com/2010-04-01/Accounts/{}/Messages/{}.json",
-            self.account_sid, message_id
+            "{}/2010-04-01/Accounts/{}/Messages/{}.json",
+            self.base_url, self.account_sid, message_id
         );
 
         let resp = self
@@ -193,5 +201,44 @@ mod tests {
             map_twilio_status("something_else"),
             DeliveryStatus::Sent
         ));
+    }
+
+    #[tokio::test]
+    async fn check_status_returns_delivered() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/2010-04-01/Accounts/AC123/Messages/SM123.json"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"status": "delivered"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let sender = TwilioSmsSender::new("AC123".into(), "token".into(), Some("+1".into()))
+            .with_base_url(mock_server.uri());
+        let status = sender.check_status("SM123").await.unwrap();
+        assert!(matches!(status, DeliveryStatus::Delivered));
+    }
+
+    #[tokio::test]
+    async fn check_status_returns_error_on_failure() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/2010-04-01/Accounts/AC123/Messages/SM999.json"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&mock_server)
+            .await;
+
+        let sender = TwilioSmsSender::new("AC123".into(), "token".into(), Some("+1".into()))
+            .with_base_url(mock_server.uri());
+        let result = sender.check_status("SM999").await;
+        assert!(matches!(result, Err(ChorusError::Provider { .. })));
     }
 }

--- a/crates/chorus-server/Cargo.toml
+++ b/crates/chorus-server/Cargo.toml
@@ -26,6 +26,7 @@ dotenvy = { workspace = true }
 rand = { workspace = true }
 hex = { workspace = true }
 async-trait = { workspace = true }
+hickory-resolver = { workspace = true }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/chorus-server/src/app.rs
+++ b/crates/chorus-server/src/app.rs
@@ -3,6 +3,7 @@ use axum::Router;
 use sqlx::PgPool;
 use std::sync::Arc;
 
+use crate::config::Config;
 use crate::db::postgres::PgRepository;
 use crate::db::provider_config::PgProviderConfigRepository;
 use crate::db::{AccountRepository, ApiKeyRepository, MessageRepository, ProviderConfigRepository};
@@ -14,6 +15,8 @@ pub struct AppState {
     pub db: Option<PgPool>,
     /// Redis client for queue, caching, and OTP.
     pub redis: redis::Client,
+    /// Server configuration.
+    config: Arc<Config>,
     /// Account + API key repository.
     account_repo: Arc<dyn AccountRepository>,
     /// Message repository.
@@ -26,12 +29,13 @@ pub struct AppState {
 
 impl AppState {
     /// Create app state backed by PostgreSQL.
-    pub fn new(db: PgPool, redis: redis::Client) -> Self {
+    pub fn new(db: PgPool, redis: redis::Client, config: Arc<Config>) -> Self {
         let repo = Arc::new(PgRepository::new(db.clone()));
         let provider_config_repo = Arc::new(PgProviderConfigRepository::new(db.clone()));
         Self {
             db: Some(db),
             redis,
+            config,
             account_repo: repo.clone(),
             message_repo: repo.clone(),
             api_key_repo: repo,
@@ -42,6 +46,7 @@ impl AppState {
     /// Create app state with custom repositories (for testing).
     pub fn with_repos(
         redis: redis::Client,
+        config: Arc<Config>,
         account_repo: Arc<dyn AccountRepository>,
         message_repo: Arc<dyn MessageRepository>,
         api_key_repo: Arc<dyn ApiKeyRepository>,
@@ -50,6 +55,7 @@ impl AppState {
         Self {
             db: None,
             redis,
+            config,
             account_repo,
             message_repo,
             api_key_repo,
@@ -75,6 +81,11 @@ impl AppState {
     /// Access the provider config repository.
     pub fn provider_config_repo(&self) -> Arc<dyn ProviderConfigRepository> {
         Arc::clone(&self.provider_config_repo)
+    }
+
+    /// Access the server configuration.
+    pub fn config(&self) -> &Config {
+        &self.config
     }
 }
 
@@ -102,5 +113,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/v1/providers/{id}",
             delete(routes::provider_configs::delete_provider_config),
         )
+        .route("/internal/bounces", post(routes::internal::handle_bounce))
+        .route("/internal/dns-check", get(routes::internal::dns_check))
         .with_state(state)
 }

--- a/crates/chorus-server/src/config.rs
+++ b/crates/chorus-server/src/config.rs
@@ -48,6 +48,9 @@ pub struct Config {
     pub smtp_password: Option<String>,
     /// Default sender email address.
     pub from_email: Option<String>,
+
+    /// Shared secret for chorus-mail bounce webhook.
+    pub bounce_secret: Option<String>,
 }
 
 impl Config {
@@ -86,6 +89,8 @@ impl Config {
             smtp_username: std::env::var("SMTP_USERNAME").ok(),
             smtp_password: std::env::var("SMTP_PASSWORD").ok(),
             from_email: std::env::var("FROM_EMAIL").ok(),
+
+            bounce_secret: std::env::var("BOUNCE_SECRET").ok(),
         }
     }
 }

--- a/crates/chorus-server/src/main.rs
+++ b/crates/chorus-server/src/main.rs
@@ -13,13 +13,14 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let config = Arc::new(Config::from_env());
+    let config = Config::from_env();
 
     let db = sqlx::PgPool::connect(&config.database_url).await?;
     sqlx::migrate!("src/db/migrations").run(&db).await?;
 
     let redis = redis::Client::open(config.redis_url.as_str())?;
-    let state = AppState::new(db, redis);
+    let config = Arc::new(config);
+    let state = AppState::new(db, redis, Arc::clone(&config));
     let state = Arc::new(state);
 
     // Spawn background queue workers and delayed poller

--- a/crates/chorus-server/src/routes/internal.rs
+++ b/crates/chorus-server/src/routes/internal.rs
@@ -1,0 +1,107 @@
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::app::AppState;
+
+/// Bounce notification from chorus-mail.
+#[derive(Deserialize)]
+pub struct BounceNotification {
+    pub recipient: String,
+    pub reason: String,
+    pub message_id: String,
+}
+
+/// DNS check result.
+#[derive(Serialize)]
+pub struct DnsCheckResult {
+    pub spf: bool,
+    pub dkim: bool,
+    pub dmarc: bool,
+    pub mx: bool,
+}
+
+/// Receive bounce notification from chorus-mail.
+pub async fn handle_bounce(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<BounceNotification>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    // Validate shared secret
+    let expected = state.config().bounce_secret.as_deref().unwrap_or("");
+    let provided = headers
+        .get("x-chorus-secret")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if expected.is_empty() || provided != expected {
+        return Err((StatusCode::UNAUTHORIZED, "invalid secret".into()));
+    }
+
+    tracing::warn!(
+        recipient = %body.recipient,
+        reason = %body.reason,
+        "bounce received from chorus-mail"
+    );
+
+    // TODO: look up message by provider message_id and update status to "bounced"
+    // For now, log the bounce. Full implementation requires a message lookup by
+    // provider_message_id which can be added as a follow-up.
+
+    Ok(StatusCode::OK)
+}
+
+#[derive(Deserialize)]
+pub struct DnsCheckQuery {
+    pub domain: String,
+}
+
+/// Check DNS records for a domain.
+pub async fn dns_check(
+    axum::extract::Query(params): axum::extract::Query<DnsCheckQuery>,
+) -> Result<Json<DnsCheckResult>, (StatusCode, String)> {
+    let domain = &params.domain;
+
+    let resolver = hickory_resolver::TokioResolver::builder_tokio()
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("resolver error: {}", e),
+            )
+        })?
+        .build();
+
+    let spf = check_txt_record(&resolver, domain, "v=spf1").await;
+    let dkim = check_txt_record(
+        &resolver,
+        &format!("chorus._domainkey.{}", domain),
+        "v=DKIM1",
+    )
+    .await;
+    let dmarc = check_txt_record(&resolver, &format!("_dmarc.{}", domain), "v=DMARC1").await;
+    let mx = check_mx_record(&resolver, domain).await;
+
+    Ok(Json(DnsCheckResult {
+        spf,
+        dkim,
+        dmarc,
+        mx,
+    }))
+}
+
+async fn check_txt_record(
+    resolver: &hickory_resolver::TokioResolver,
+    name: &str,
+    prefix: &str,
+) -> bool {
+    match resolver.txt_lookup(name).await {
+        Ok(lookup) => lookup.iter().any(|txt| txt.to_string().contains(prefix)),
+        Err(_) => false,
+    }
+}
+
+async fn check_mx_record(resolver: &hickory_resolver::TokioResolver, domain: &str) -> bool {
+    resolver.mx_lookup(domain).await.is_ok()
+}

--- a/crates/chorus-server/src/routes/mod.rs
+++ b/crates/chorus-server/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod email;
 pub mod health;
+pub mod internal;
 pub mod keys;
 pub mod messages;
 pub mod otp;

--- a/crates/chorus-server/tests/api_test.rs
+++ b/crates/chorus-server/tests/api_test.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 // Re-use types from chorus-server
 use chorus_server::app::{create_router, AppState};
+use chorus_server::config::Config;
 use chorus_server::db::{
     Account, AccountRepository, ApiKey, ApiKeyRepository, DbError, DeliveryEvent, Message,
     MessageRepository, NewMessage, NewProviderConfig, Pagination, ProviderConfig,
@@ -239,8 +240,10 @@ fn test_state() -> Arc<AppState> {
     // but auth + DB-only tests will work
     let redis = redis::Client::open("redis://127.0.0.1:6379").unwrap();
 
+    let config = Arc::new(Config::from_env());
     Arc::new(AppState::with_repos(
         redis,
+        config,
         account_repo,
         message_repo,
         api_key_repo,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,22 @@ services:
       PORT: "3000"
       WORKER_CONCURRENCY: "4"
       RUST_LOG: chorus_server=debug,tower_http=debug
+      BOUNCE_SECRET: ${BOUNCE_SECRET:-changeme}
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
+
+  chorus-mail:
+    build: ./chorus-mail
+    environment:
+      MAIL_DOMAIN: ${MAIL_DOMAIN:-example.com}
+      CHORUS_SERVER_URL: http://chorus-server:3000
+      BOUNCE_SECRET: ${BOUNCE_SECRET:-changeme}
+    ports:
+      - "25:25"
+      - "587:587"
 
 volumes:
   pgdata:

--- a/docs/guides/auth-service-integration.md
+++ b/docs/guides/auth-service-integration.md
@@ -1,0 +1,174 @@
+# Auth Service Integration Guide
+
+How to integrate Chorus into your authentication service for sending OTP codes, password resets, magic links, and email verification.
+
+## Adapter Pattern (Rust — Nucleus Example)
+
+Wrap Chorus in a thin adapter so your auth service depends on a local trait, not Chorus directly:
+
+```rust
+use chorus_core::client::Chorus;
+use chorus_core::types::{SmsMessage, TemplateEmailMessage};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct NotificationService {
+    chorus: Arc<Chorus>,
+    app_name: String,
+}
+
+impl NotificationService {
+    pub fn new(chorus: Arc<Chorus>, app_name: String) -> Self {
+        Self { chorus, app_name }
+    }
+
+    pub async fn send_otp(&self, to_email: &str, code: &str) -> Result<(), AppError> {
+        let vars = HashMap::from([
+            ("code".into(), code.into()),
+            ("app_name".into(), self.app_name.clone()),
+            ("expiry".into(), "10 minutes".into()),
+        ]);
+        self.chorus
+            .send_template_email(&TemplateEmailMessage {
+                to: to_email.into(),
+                from: None,
+                template_slug: "otp".into(),
+                variables: vars,
+            })
+            .await
+            .map_err(AppError::from)?;
+        Ok(())
+    }
+}
+```
+
+## Error Mapping
+
+Map `ChorusError` to your app's error type:
+
+```rust
+impl From<ChorusError> for AppError {
+    fn from(err: ChorusError) -> Self {
+        match err {
+            ChorusError::Validation(msg) => AppError::BadRequest(msg),
+            ChorusError::RateLimited { retry_after_secs } => {
+                AppError::TooManyRequests(retry_after_secs)
+            }
+            _ => AppError::Internal(err.to_string()),
+        }
+    }
+}
+```
+
+## REST API (Java — Orbit Example)
+
+For non-Rust services, use the Chorus REST API:
+
+```java
+// POST /v1/email/send
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://chorus:3000/v1/email/send"))
+    .header("Authorization", "Bearer ch_live_xxx")
+    .header("Content-Type", "application/json")
+    .POST(HttpRequest.BodyPublishers.ofString("""
+        {
+            "to": "user@example.com",
+            "template_slug": "password-reset",
+            "variables": {
+                "app_name": "Orbit",
+                "reset_url": "https://orbit.app/reset?token=abc",
+                "expiry": "1 hour"
+            }
+        }
+    """))
+    .build();
+```
+
+## SMTP Provider Configuration
+
+### SendGrid via SMTP
+
+```env
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USERNAME=apikey
+SMTP_PASSWORD=SG.your-api-key
+FROM_EMAIL=noreply@yourdomain.com
+```
+
+### Mailgun via SMTP
+
+```env
+SMTP_HOST=smtp.mailgun.org
+SMTP_PORT=587
+SMTP_USERNAME=postmaster@yourdomain.com
+SMTP_PASSWORD=your-mailgun-password
+FROM_EMAIL=noreply@yourdomain.com
+```
+
+### Gmail via SMTP (dev only)
+
+```env
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=you@gmail.com
+SMTP_PASSWORD=your-app-password
+FROM_EMAIL=you@gmail.com
+```
+
+## chorus-mail (Self-Hosted)
+
+For zero-cost email delivery, use the built-in chorus-mail Docker image:
+
+```bash
+# 1. Start the stack
+MAIL_DOMAIN=yourdomain.com docker compose up -d
+
+# 2. Print required DNS records
+docker compose exec chorus-mail /scripts/dns-setup.sh
+
+# 3. Add the printed DNS records (MX, SPF, DKIM, DMARC) to your DNS provider
+
+# 4. Configure chorus-server to use local SMTP
+SMTP_HOST=chorus-mail
+SMTP_PORT=587
+FROM_EMAIL=noreply@yourdomain.com
+```
+
+## OTP Routing (Auto-detect Email/Phone)
+
+Chorus can auto-route OTP delivery based on the recipient format:
+
+```rust
+// Email detected → uses email template
+chorus.send_otp("user@example.com", "123456").await?;
+
+// Phone detected → sends SMS
+chorus.send_otp("+66812345678", "123456").await?;
+```
+
+## Test Mode
+
+Use `ch_test_` prefixed API keys during development. Test mode logs messages without sending them to real providers:
+
+```env
+# In development
+CHORUS_API_KEY=ch_test_abc123
+
+# In production
+CHORUS_API_KEY=ch_live_abc123
+```
+
+## Built-in Templates
+
+Chorus ships with 5 auth templates ready to use:
+
+| Slug | Variables | Use Case |
+|------|-----------|----------|
+| `otp` | `code`, `app_name`, `expiry` | 2FA / verification codes |
+| `password-reset` | `reset_url`, `app_name`, `expiry` | Password reset links |
+| `magic-link` | `magic_url`, `app_name`, `expiry` | Passwordless sign-in |
+| `email-verify` | `verify_url`, `app_name` | New account email verification |
+| `welcome` | `user_name`, `app_name` | Post-signup welcome email |
+
+All templates support Jinja2 syntax (`{% if %}`, `{% for %}`, `{{ var | default('x') }}`).


### PR DESCRIPTION
## Summary
- **Phase 3a:** Implement real `check_status()` for Twilio, Telnyx, and Plivo SMS providers (replacing stubs)
- **Phase 3b:** Replace simple `{{var}}` template engine with minijinja (Jinja2 syntax: conditionals, loops, filters) + add 5 built-in auth templates (otp, password-reset, magic-link, email-verify, welcome)
- **Phase 3c:** Add self-hosted email infrastructure — chorus-mail Docker image (Postfix + OpenDKIM), bounce webhook + DNS check endpoints in chorus-server, docker-compose integration, and auth service integration guide

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — formatted
- [x] `cargo deny check` — license/advisory audit
- [x] `docker compose build` — chorus-mail image builds
- [x] Manual: verify DNS check endpoint returns correct results
- [x] Manual: verify bounce webhook rejects invalid secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3