### PR TITLE
feat: rename SDK imports from chorus_core:: to chorus::

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Rust backend (Axum) with waterfall routing — email first (free), SMS fallback 
 ## Quick Start
 
 ```rust
-use chorus_core::client::Chorus;
-use chorus_core::types::SmsMessage;
+use chorus::client::Chorus;
+use chorus::types::SmsMessage;
 use std::sync::Arc;
 
 let chorus = Chorus::builder()

--- a/crates/chorus-core/Cargo.toml
+++ b/crates/chorus-core/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["api-bindings", "network-programming"]
 readme = "README.md"
 rust-version = "1.85.0"
 
+[lib]
+name = "chorus"
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/chorus-core/README.md
+++ b/crates/chorus-core/README.md
@@ -12,8 +12,8 @@ Core traits, types, and routing engine for [Chorus](https://github.com/cntm-labs
 ## Usage
 
 ```rust
-use chorus_core::client::Chorus;
-use chorus_core::types::SmsMessage;
+use chorus::client::Chorus;
+use chorus::types::SmsMessage;
 
 let chorus = Chorus::builder()
     .add_sms_provider(my_provider)

--- a/crates/chorus-core/src/lib.rs
+++ b/crates/chorus-core/src/lib.rs
@@ -16,11 +16,11 @@
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use chorus_core::client::Chorus;
-//! use chorus_core::types::SmsMessage;
+//! use chorus::client::Chorus;
+//! use chorus::types::SmsMessage;
 //! use std::sync::Arc;
 //!
-//! # async fn example() -> Result<(), chorus_core::error::ChorusError> {
+//! # async fn example() -> Result<(), chorus::error::ChorusError> {
 //! let chorus = Chorus::builder()
 //!     // .add_sms_provider(Arc::new(my_provider))
 //!     .default_from_sms("+1234567890".into())

--- a/crates/chorus-core/tests/sdk_import.rs
+++ b/crates/chorus-core/tests/sdk_import.rs
@@ -1,0 +1,5 @@
+/// Verify the crate is importable as `chorus::` (not `chorus_core::`)
+#[test]
+fn sdk_import_name() {
+    let _ = chorus::client::Chorus::builder();
+}

--- a/crates/chorus-providers/README.md
+++ b/crates/chorus-providers/README.md
@@ -26,7 +26,7 @@ let sms = TelnyxSmsSender::new("api_key".into(), Some("+1234567890".into()));
 let email = ResendEmailSender::new("api_key".into(), "noreply@example.com".into());
 ```
 
-All providers implement `chorus_core::sms::SmsSender` or `chorus_core::email::EmailSender`.
+All providers implement `chorus::sms::SmsSender` or `chorus::email::EmailSender`.
 
 See the [main repository](https://github.com/cntm-labs/chorus) for full documentation.
 

--- a/crates/chorus-providers/src/email/mock.rs
+++ b/crates/chorus-providers/src/email/mock.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use chorus_core::email::EmailSender;
-use chorus_core::error::ChorusError;
-use chorus_core::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
+use chorus::email::EmailSender;
+use chorus::error::ChorusError;
+use chorus::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
 use chrono::Utc;
 use uuid::Uuid;
 

--- a/crates/chorus-providers/src/email/resend.rs
+++ b/crates/chorus-providers/src/email/resend.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use chorus_core::email::EmailSender;
-use chorus_core::error::ChorusError;
-use chorus_core::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
+use chorus::email::EmailSender;
+use chorus::error::ChorusError;
+use chorus::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
 use chrono::Utc;
 use serde::Deserialize;
 

--- a/crates/chorus-providers/src/email/ses.rs
+++ b/crates/chorus-providers/src/email/ses.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use chorus_core::email::EmailSender;
-use chorus_core::error::ChorusError;
-use chorus_core::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
+use chorus::email::EmailSender;
+use chorus::error::ChorusError;
+use chorus::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
 use chrono::Utc;
 use lettre::message::header::ContentType;
 use lettre::message::MultiPart;

--- a/crates/chorus-providers/src/email/smtp.rs
+++ b/crates/chorus-providers/src/email/smtp.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use chorus_core::email::EmailSender;
-use chorus_core::error::ChorusError;
-use chorus_core::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
+use chorus::email::EmailSender;
+use chorus::error::ChorusError;
+use chorus::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
 use chrono::Utc;
 use lettre::message::header::ContentType;
 use lettre::message::MultiPart;

--- a/crates/chorus-providers/src/lib.rs
+++ b/crates/chorus-providers/src/lib.rs
@@ -20,9 +20,9 @@
 //! | SMTP | [`email::smtp::SmtpEmailSender`] | SMTP |
 //! | Mock | [`email::mock::MockEmailSender`] | In-memory (testing) |
 //!
-//! All providers implement [`chorus_core::sms::SmsSender`] or
-//! [`chorus_core::email::EmailSender`] and can be used interchangeably
-//! with [`chorus_core::router::WaterfallRouter`].
+//! All providers implement [`chorus::sms::SmsSender`] or
+//! [`chorus::email::EmailSender`] and can be used interchangeably
+//! with [`chorus::router::WaterfallRouter`].
 
 pub mod email;
 pub mod sms;

--- a/crates/chorus-providers/src/sms/mock.rs
+++ b/crates/chorus-providers/src/sms/mock.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use chorus_core::error::ChorusError;
-use chorus_core::sms::SmsSender;
-use chorus_core::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
+use chorus::error::ChorusError;
+use chorus::sms::SmsSender;
+use chorus::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
 use chrono::Utc;
 use uuid::Uuid;
 

--- a/crates/chorus-providers/src/sms/plivo.rs
+++ b/crates/chorus-providers/src/sms/plivo.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use chorus_core::error::ChorusError;
-use chorus_core::sms::SmsSender;
-use chorus_core::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
+use chorus::error::ChorusError;
+use chorus::sms::SmsSender;
+use chorus::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
 use chrono::Utc;
 use serde::Deserialize;
 

--- a/crates/chorus-providers/src/sms/telnyx.rs
+++ b/crates/chorus-providers/src/sms/telnyx.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use chorus_core::error::ChorusError;
-use chorus_core::sms::SmsSender;
-use chorus_core::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
+use chorus::error::ChorusError;
+use chorus::sms::SmsSender;
+use chorus::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
 use chrono::Utc;
 use serde::Deserialize;
 

--- a/crates/chorus-providers/src/sms/twilio.rs
+++ b/crates/chorus-providers/src/sms/twilio.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use chorus_core::error::ChorusError;
-use chorus_core::sms::SmsSender;
-use chorus_core::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
+use chorus::error::ChorusError;
+use chorus::sms::SmsSender;
+use chorus::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
 use chrono::Utc;
 use serde::Deserialize;
 

--- a/crates/chorus-server/src/queue/router_builder.rs
+++ b/crates/chorus-server/src/queue/router_builder.rs
@@ -1,4 +1,4 @@
-use chorus_core::router::WaterfallRouter;
+use chorus::router::WaterfallRouter;
 use chorus_providers::email::mock::MockEmailSender;
 use chorus_providers::email::resend::ResendEmailSender;
 use chorus_providers::email::ses::SesEmailSender;

--- a/crates/chorus-server/src/queue/worker.rs
+++ b/crates/chorus-server/src/queue/worker.rs
@@ -1,4 +1,4 @@
-use chorus_core::types::{EmailMessage, SmsMessage};
+use chorus::types::{EmailMessage, SmsMessage};
 use std::sync::Arc;
 
 use crate::app::AppState;

--- a/docs/guides/auth-service-integration.md
+++ b/docs/guides/auth-service-integration.md
@@ -7,8 +7,8 @@ How to integrate Chorus into your authentication service for sending OTP codes, 
 Wrap Chorus in a thin adapter so your auth service depends on a local trait, not Chorus directly:
 
 ```rust
-use chorus_core::client::Chorus;
-use chorus_core::types::{SmsMessage, TemplateEmailMessage};
+use chorus::client::Chorus;
+use chorus::types::{SmsMessage, TemplateEmailMessage};
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/docs/plans/2026-04-01-chorus-phase1-implementation.md
+++ b/docs/plans/2026-04-01-chorus-phase1-implementation.md
@@ -421,9 +421,9 @@ git commit -m "feat(core): add SmsSender and EmailSender traits"
 ```rust
 // crates/chorus-providers/src/sms/mock.rs
 use async_trait::async_trait;
-use chorus_core::error::ChorusError;
-use chorus_core::sms::SmsSender;
-use chorus_core::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
+use chorus::error::ChorusError;
+use chorus::sms::SmsSender;
+use chorus::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
 use chrono::Utc;
 use uuid::Uuid;
 
@@ -491,9 +491,9 @@ mod tests {
 ```rust
 // crates/chorus-providers/src/email/mock.rs
 use async_trait::async_trait;
-use chorus_core::email::EmailSender;
-use chorus_core::error::ChorusError;
-use chorus_core::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
+use chorus::email::EmailSender;
+use chorus::error::ChorusError;
+use chorus::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
 use chrono::Utc;
 use uuid::Uuid;
 
@@ -894,9 +894,9 @@ git commit -m "feat(core): add WaterfallRouter with email-first/SMS-fallback and
 ```rust
 // crates/chorus-providers/src/sms/telnyx.rs
 use async_trait::async_trait;
-use chorus_core::error::ChorusError;
-use chorus_core::sms::SmsSender;
-use chorus_core::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
+use chorus::error::ChorusError;
+use chorus::sms::SmsSender;
+use chorus::types::{Channel, DeliveryStatus, SendResult, SmsMessage};
 use chrono::Utc;
 use serde::Deserialize;
 
@@ -1082,9 +1082,9 @@ git commit -m "feat(providers): add PlivoSmsSender"
 ```rust
 // crates/chorus-providers/src/email/resend.rs
 use async_trait::async_trait;
-use chorus_core::email::EmailSender;
-use chorus_core::error::ChorusError;
-use chorus_core::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
+use chorus::email::EmailSender;
+use chorus::error::ChorusError;
+use chorus::types::{Channel, DeliveryStatus, EmailMessage, SendResult};
 use chrono::Utc;
 use serde::Deserialize;
 

--- a/docs/plans/2026-04-05-chorus-server-phase2b-implementation.md
+++ b/docs/plans/2026-04-05-chorus-server-phase2b-implementation.md
@@ -286,7 +286,7 @@ git commit -m "feat(server): add provider env vars and worker_concurrency to Con
 Builds a `WaterfallRouter` from per-account DB config or global env defaults. Test mode always uses mock providers.
 
 ```rust
-use chorus_core::router::WaterfallRouter;
+use chorus::router::WaterfallRouter;
 use chorus_providers::email::mock::MockEmailSender;
 use chorus_providers::email::resend::ResendEmailSender;
 use chorus_providers::email::ses::SesEmailSender;
@@ -651,7 +651,7 @@ git commit -m "feat(server): add delayed retry queue and dead letter queue"
 ### Step 1: Rewrite worker.rs
 
 ```rust
-use chorus_core::types::{EmailMessage, SmsMessage};
+use chorus::types::{EmailMessage, SmsMessage};
 use std::sync::Arc;
 
 use crate::app::AppState;

--- a/docs/plans/2026-04-05-crates-io-release-prep-implementation.md
+++ b/docs/plans/2026-04-05-crates-io-release-prep-implementation.md
@@ -120,11 +120,11 @@ Replace the entire `crates/chorus-core/src/lib.rs` with:
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use chorus_core::client::Chorus;
-//! use chorus_core::types::SmsMessage;
+//! use chorus::client::Chorus;
+//! use chorus::types::SmsMessage;
 //! use std::sync::Arc;
 //!
-//! # async fn example() -> Result<(), chorus_core::error::ChorusError> {
+//! # async fn example() -> Result<(), chorus::error::ChorusError> {
 //! let chorus = Chorus::builder()
 //!     // .add_sms_provider(Arc::new(my_provider))
 //!     .default_from_sms("+1234567890".into())
@@ -386,9 +386,9 @@ Replace `crates/chorus-providers/src/lib.rs` with:
 //! | SMTP | [`email::smtp::SmtpEmailSender`] | SMTP |
 //! | Mock | [`email::mock::MockEmailSender`] | In-memory (testing) |
 //!
-//! All providers implement [`chorus_core::sms::SmsSender`] or
-//! [`chorus_core::email::EmailSender`] and can be used interchangeably
-//! with [`chorus_core::router::WaterfallRouter`].
+//! All providers implement [`chorus::sms::SmsSender`] or
+//! [`chorus::email::EmailSender`] and can be used interchangeably
+//! with [`chorus::router::WaterfallRouter`].
 
 pub mod email;
 pub mod sms;
@@ -431,8 +431,8 @@ Core traits, types, and routing engine for [Chorus](https://github.com/cntm-labs
 ## Usage
 
 ```rust
-use chorus_core::client::Chorus;
-use chorus_core::types::SmsMessage;
+use chorus::client::Chorus;
+use chorus::types::SmsMessage;
 
 let chorus = Chorus::builder()
     .add_sms_provider(my_provider)
@@ -485,7 +485,7 @@ let sms = TelnyxSmsSender::new("api_key".into(), Some("+1234567890".into()));
 let email = ResendEmailSender::new("api_key".into(), "noreply@example.com".into());
 ```
 
-All providers implement `chorus_core::sms::SmsSender` or `chorus_core::email::EmailSender`.
+All providers implement `chorus::sms::SmsSender` or `chorus::email::EmailSender`.
 
 See the [main repository](https://github.com/cntm-labs/chorus) for full documentation.
 


### PR DESCRIPTION
## Summary
- Add `[lib] name = "chorus"` to `chorus-core/Cargo.toml` so Rust imports use `use chorus::` instead of `use chorus_core::`
- Update all imports across `chorus-providers`, `chorus-server`, and documentation
- Add integration test verifying `chorus::` import name works

## Test plan
- [x] `cargo test --workspace` — 90 tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] Integration test `sdk_import_name` confirms `chorus::client::Chorus::builder()` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)