### PR TITLE
feat(server): batch send endpoints for SMS and Email

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minijinja"
 version = "2.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1872,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1873,6 +1884,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -2754,6 +2766,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/chorus-server/src/app.rs
+++ b/crates/chorus-server/src/app.rs
@@ -136,6 +136,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/v1/webhooks/{id}",
             delete(routes::webhooks::delete_webhook),
         )
+        .route("/v1/sms/send-batch", post(routes::batch::send_sms_batch))
+        .route(
+            "/v1/email/send-batch",
+            post(routes::batch::send_email_batch),
+        )
         .route("/internal/bounces", post(routes::internal::handle_bounce))
         .route("/internal/dns-check", get(routes::internal::dns_check))
         .with_state(state)

--- a/crates/chorus-server/src/routes/batch.rs
+++ b/crates/chorus-server/src/routes/batch.rs
@@ -1,0 +1,184 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::api_key::AccountContext;
+use crate::db::NewMessage;
+use crate::queue::SendJob;
+
+/// Maximum recipients per batch request.
+const MAX_BATCH_SIZE: usize = 100;
+
+/// A single SMS recipient in a batch.
+#[derive(Deserialize)]
+pub struct SmsBatchRecipient {
+    /// Recipient phone number in E.164 format.
+    pub to: String,
+    /// Message body.
+    pub body: String,
+}
+
+/// SMS batch send request.
+#[derive(Deserialize)]
+pub struct SendSmsBatchRequest {
+    /// Optional sender ID or phone number.
+    pub from: Option<String>,
+    /// List of recipients with individual message bodies.
+    pub recipients: Vec<SmsBatchRecipient>,
+}
+
+/// A single email recipient in a batch.
+#[derive(Deserialize)]
+pub struct EmailBatchRecipient {
+    /// Recipient email address.
+    pub to: String,
+    /// Email subject line.
+    pub subject: String,
+    /// Email body (HTML or plain text).
+    pub body: String,
+}
+
+/// Email batch send request.
+#[derive(Deserialize)]
+pub struct SendEmailBatchRequest {
+    /// Optional sender address.
+    pub from: Option<String>,
+    /// List of recipients with individual subjects and bodies.
+    pub recipients: Vec<EmailBatchRecipient>,
+}
+
+/// One message result in the batch response.
+#[derive(Serialize)]
+pub struct BatchMessageResult {
+    pub message_id: Uuid,
+    pub to: String,
+    pub status: &'static str,
+}
+
+/// Batch send response.
+#[derive(Serialize)]
+pub struct BatchSendResponse {
+    pub messages: Vec<BatchMessageResult>,
+}
+
+/// Queue a batch of SMS messages. Returns 202 Accepted.
+pub async fn send_sms_batch(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Json(req): Json<SendSmsBatchRequest>,
+) -> Result<(StatusCode, Json<BatchSendResponse>), (StatusCode, String)> {
+    validate_batch_size(req.recipients.len())?;
+
+    let mut results = Vec::with_capacity(req.recipients.len());
+
+    for recipient in &req.recipients {
+        let new_msg = NewMessage {
+            account_id: ctx.account_id,
+            api_key_id: ctx.key_id,
+            channel: "sms".into(),
+            sender: req.from.clone(),
+            recipient: recipient.to.clone(),
+            subject: None,
+            body: recipient.body.clone(),
+            environment: ctx.environment.clone(),
+        };
+
+        let message = state
+            .message_repo()
+            .insert(&new_msg)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        let job = SendJob {
+            message_id: message.id,
+            account_id: message.account_id,
+            channel: "sms".into(),
+            environment: message.environment.clone(),
+            attempt: 0,
+        };
+        crate::queue::enqueue::enqueue_job(&state, &job)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        results.push(BatchMessageResult {
+            message_id: message.id,
+            to: recipient.to.clone(),
+            status: "queued",
+        });
+    }
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(BatchSendResponse { messages: results }),
+    ))
+}
+
+/// Queue a batch of email messages. Returns 202 Accepted.
+pub async fn send_email_batch(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Json(req): Json<SendEmailBatchRequest>,
+) -> Result<(StatusCode, Json<BatchSendResponse>), (StatusCode, String)> {
+    validate_batch_size(req.recipients.len())?;
+
+    let mut results = Vec::with_capacity(req.recipients.len());
+
+    for recipient in &req.recipients {
+        let new_msg = NewMessage {
+            account_id: ctx.account_id,
+            api_key_id: ctx.key_id,
+            channel: "email".into(),
+            sender: req.from.clone(),
+            recipient: recipient.to.clone(),
+            subject: Some(recipient.subject.clone()),
+            body: recipient.body.clone(),
+            environment: ctx.environment.clone(),
+        };
+
+        let message = state
+            .message_repo()
+            .insert(&new_msg)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        let job = SendJob {
+            message_id: message.id,
+            account_id: message.account_id,
+            channel: "email".into(),
+            environment: message.environment.clone(),
+            attempt: 0,
+        };
+        crate::queue::enqueue::enqueue_job(&state, &job)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        results.push(BatchMessageResult {
+            message_id: message.id,
+            to: recipient.to.clone(),
+            status: "queued",
+        });
+    }
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(BatchSendResponse { messages: results }),
+    ))
+}
+
+/// Validate that the batch size is within bounds.
+fn validate_batch_size(size: usize) -> Result<(), (StatusCode, String)> {
+    if size == 0 {
+        return Err((StatusCode::BAD_REQUEST, "recipients cannot be empty".into()));
+    }
+    if size > MAX_BATCH_SIZE {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("max {MAX_BATCH_SIZE} recipients per batch"),
+        ));
+    }
+    Ok(())
+}

--- a/crates/chorus-server/src/routes/mod.rs
+++ b/crates/chorus-server/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod batch;
 pub mod email;
 pub mod health;
 pub mod internal;


### PR DESCRIPTION
## Summary
- Add `POST /v1/sms/send-batch` and `POST /v1/email/send-batch` endpoints
- Max 100 recipients per batch, each message enqueued as an independent job
- Reuses existing single-send infra (insert → enqueue → worker retry/failover)

Closes #17

## New files
| File | Purpose |
|------|---------|
| `routes/batch.rs` | Batch send handlers for SMS and Email |

## Modified files
| File | Change |
|------|--------|
| `routes/mod.rs` | Add `batch` module |
| `app.rs` | Wire batch routes into router |

## API

### `POST /v1/sms/send-batch`
```json
{
  "from": "+1234567890",
  "recipients": [
    { "to": "+1111111111", "body": "Hello" },
    { "to": "+2222222222", "body": "World" }
  ]
}
```

### `POST /v1/email/send-batch`
```json
{
  "from": "noreply@example.com",
  "recipients": [
    { "to": "a@example.com", "subject": "Hi", "body": "<p>Hello</p>" },
    { "to": "b@example.com", "subject": "Hey", "body": "<p>World</p>" }
  ]
}
```

### Response (202 Accepted)
```json
{
  "messages": [
    { "message_id": "uuid", "to": "...", "status": "queued" }
  ]
}
```

## Test plan
- [x] `cargo test --workspace` — 95 tests pass, 0 failures
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo deny check` — clean
- [ ] Manual: send batch SMS via API and verify all messages queued
- [ ] Manual: send batch email via API and verify all messages queued
- [ ] Manual: verify 101-recipient request returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)