### PR TITLE
fix(server): batch send partial failure handling + tests

### DIFF
--- a/crates/chorus-server/src/routes/batch.rs
+++ b/crates/chorus-server/src/routes/batch.rs
@@ -98,10 +98,7 @@ pub async fn send_sms_batch(
                     StatusCode::ACCEPTED,
                     Json(BatchSendResponse {
                         messages: results,
-                        error: Some(format!(
-                            "failed at recipient {}: {}",
-                            recipient.to, e
-                        )),
+                        error: Some(format!("failed at recipient {}: {}", recipient.to, e)),
                     }),
                 ));
             }
@@ -119,10 +116,7 @@ pub async fn send_sms_batch(
                 StatusCode::ACCEPTED,
                 Json(BatchSendResponse {
                     messages: results,
-                    error: Some(format!(
-                        "failed to enqueue for {}: {}",
-                        recipient.to, e
-                    )),
+                    error: Some(format!("failed to enqueue for {}: {}", recipient.to, e)),
                 }),
             ));
         }
@@ -174,10 +168,7 @@ pub async fn send_email_batch(
                     StatusCode::ACCEPTED,
                     Json(BatchSendResponse {
                         messages: results,
-                        error: Some(format!(
-                            "failed at recipient {}: {}",
-                            recipient.to, e
-                        )),
+                        error: Some(format!("failed at recipient {}: {}", recipient.to, e)),
                     }),
                 ));
             }
@@ -195,10 +186,7 @@ pub async fn send_email_batch(
                 StatusCode::ACCEPTED,
                 Json(BatchSendResponse {
                     messages: results,
-                    error: Some(format!(
-                        "failed to enqueue for {}: {}",
-                        recipient.to, e
-                    )),
+                    error: Some(format!("failed to enqueue for {}: {}", recipient.to, e)),
                 }),
             ));
         }

--- a/crates/chorus-server/src/routes/batch.rs
+++ b/crates/chorus-server/src/routes/batch.rs
@@ -59,13 +59,17 @@ pub struct BatchMessageResult {
     pub status: &'static str,
 }
 
-/// Batch send response.
+/// Batch send response. Includes partial results if an error occurred mid-batch.
 #[derive(Serialize)]
 pub struct BatchSendResponse {
     pub messages: Vec<BatchMessageResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// Queue a batch of SMS messages. Returns 202 Accepted.
+///
+/// On partial failure, returns already-queued messages with an error field.
 pub async fn send_sms_batch(
     State(state): State<Arc<AppState>>,
     ctx: AccountContext,
@@ -87,11 +91,21 @@ pub async fn send_sms_batch(
             environment: ctx.environment.clone(),
         };
 
-        let message = state
-            .message_repo()
-            .insert(&new_msg)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let message = match state.message_repo().insert(&new_msg).await {
+            Ok(m) => m,
+            Err(e) => {
+                return Ok((
+                    StatusCode::ACCEPTED,
+                    Json(BatchSendResponse {
+                        messages: results,
+                        error: Some(format!(
+                            "failed at recipient {}: {}",
+                            recipient.to, e
+                        )),
+                    }),
+                ));
+            }
+        };
 
         let job = SendJob {
             message_id: message.id,
@@ -100,9 +114,18 @@ pub async fn send_sms_batch(
             environment: message.environment.clone(),
             attempt: 0,
         };
-        crate::queue::enqueue::enqueue_job(&state, &job)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        if let Err(e) = crate::queue::enqueue::enqueue_job(&state, &job).await {
+            return Ok((
+                StatusCode::ACCEPTED,
+                Json(BatchSendResponse {
+                    messages: results,
+                    error: Some(format!(
+                        "failed to enqueue for {}: {}",
+                        recipient.to, e
+                    )),
+                }),
+            ));
+        }
 
         results.push(BatchMessageResult {
             message_id: message.id,
@@ -113,11 +136,16 @@ pub async fn send_sms_batch(
 
     Ok((
         StatusCode::ACCEPTED,
-        Json(BatchSendResponse { messages: results }),
+        Json(BatchSendResponse {
+            messages: results,
+            error: None,
+        }),
     ))
 }
 
 /// Queue a batch of email messages. Returns 202 Accepted.
+///
+/// On partial failure, returns already-queued messages with an error field.
 pub async fn send_email_batch(
     State(state): State<Arc<AppState>>,
     ctx: AccountContext,
@@ -139,11 +167,21 @@ pub async fn send_email_batch(
             environment: ctx.environment.clone(),
         };
 
-        let message = state
-            .message_repo()
-            .insert(&new_msg)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let message = match state.message_repo().insert(&new_msg).await {
+            Ok(m) => m,
+            Err(e) => {
+                return Ok((
+                    StatusCode::ACCEPTED,
+                    Json(BatchSendResponse {
+                        messages: results,
+                        error: Some(format!(
+                            "failed at recipient {}: {}",
+                            recipient.to, e
+                        )),
+                    }),
+                ));
+            }
+        };
 
         let job = SendJob {
             message_id: message.id,
@@ -152,9 +190,18 @@ pub async fn send_email_batch(
             environment: message.environment.clone(),
             attempt: 0,
         };
-        crate::queue::enqueue::enqueue_job(&state, &job)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        if let Err(e) = crate::queue::enqueue::enqueue_job(&state, &job).await {
+            return Ok((
+                StatusCode::ACCEPTED,
+                Json(BatchSendResponse {
+                    messages: results,
+                    error: Some(format!(
+                        "failed to enqueue for {}: {}",
+                        recipient.to, e
+                    )),
+                }),
+            ));
+        }
 
         results.push(BatchMessageResult {
             message_id: message.id,
@@ -165,7 +212,10 @@ pub async fn send_email_batch(
 
     Ok((
         StatusCode::ACCEPTED,
-        Json(BatchSendResponse { messages: results }),
+        Json(BatchSendResponse {
+            messages: results,
+            error: None,
+        }),
     ))
 }
 

--- a/crates/chorus-server/tests/api_test.rs
+++ b/crates/chorus-server/tests/api_test.rs
@@ -421,3 +421,155 @@ async fn providers_list_returns_200() {
     let body = response_body(resp).await;
     assert!(body.as_array().unwrap().is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// Batch SMS tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sms_batch_without_auth_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/sms/send-batch")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    r#"{"recipients":[{"to":"+1234567890","body":"hi"}]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn sms_batch_empty_recipients_returns_400() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/sms/send-batch")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::from(r#"{"recipients":[]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn sms_batch_exceeds_max_returns_400() {
+    let app = create_router(test_state());
+
+    // Build 101 recipients (max is 100)
+    let recipients: Vec<Value> = (0..101)
+        .map(|i| {
+            serde_json::json!({
+                "to": format!("+1{:010}", i),
+                "body": "hello"
+            })
+        })
+        .collect();
+    let body = serde_json::json!({ "recipients": recipients }).to_string();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/sms/send-batch")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// Batch Email tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn email_batch_without_auth_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/email/send-batch")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    r#"{"recipients":[{"to":"a@b.com","subject":"hi","body":"hey"}]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn email_batch_empty_recipients_returns_400() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/email/send-batch")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::from(r#"{"recipients":[]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn email_batch_exceeds_max_returns_400() {
+    let app = create_router(test_state());
+
+    let recipients: Vec<Value> = (0..101)
+        .map(|i| {
+            serde_json::json!({
+                "to": format!("user{}@example.com", i),
+                "subject": "test",
+                "body": "hello"
+            })
+        })
+        .collect();
+    let body = serde_json::json!({ "recipients": recipients }).to_string();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/email/send-batch")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## Summary
- Fix all-or-nothing error handling in batch endpoints — now returns partial results with `error` field when a failure occurs mid-batch
- Add `error: Option<String>` to `BatchSendResponse` (skipped in JSON when null)
- Add 6 new tests covering auth (401) and validation (400 for empty/oversized batches)

Fixes issues from #20 where:
- Messages 1–N could be orphaned in the queue if message N+1 failed (500 response)
- `BatchSendResponse` was missing the `error` field
- No test coverage existed for batch endpoints

## Changes
| File | Change |
|------|--------|
| `routes/batch.rs` | Partial failure handling: return already-queued messages + error on failure |
| `tests/api_test.rs` | 6 new tests: auth + validation for SMS and Email batch |

## Test plan
- [x] `cargo test --workspace` — 101 tests pass (6 new batch tests)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo deny check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)