### PR TITLE
feat(server): complete webhook event dispatch (queued + sent)

### DIFF
--- a/services/chorus-server/src/queue/enqueue.rs
+++ b/services/chorus-server/src/queue/enqueue.rs
@@ -1,7 +1,10 @@
+use chrono::Utc;
+use std::sync::Arc;
+
 use crate::app::AppState;
 
 /// Push a send job onto the Redis queue.
-pub async fn enqueue_job(state: &AppState, job: &super::SendJob) -> anyhow::Result<()> {
+pub async fn job(state: &AppState, job: &super::SendJob) -> anyhow::Result<()> {
     let mut conn = state.redis.get_multiplexed_tokio_connection().await?;
     let payload = serde_json::to_string(job)?;
     redis::cmd("LPUSH")
@@ -9,5 +12,23 @@ pub async fn enqueue_job(state: &AppState, job: &super::SendJob) -> anyhow::Resu
         .arg(payload)
         .query_async::<i64>(&mut conn)
         .await?;
+    Ok(())
+}
+
+/// Enqueue a job and dispatch the `message.queued` webhook event.
+pub async fn notify(state: &Arc<AppState>, job: &super::SendJob) -> anyhow::Result<()> {
+    self::job(state, job).await?;
+
+    let payload = super::webhook_dispatch::WebhookPayload {
+        event: "message.queued".into(),
+        message_id: job.message_id,
+        channel: job.channel.clone(),
+        provider: None,
+        status: "queued".into(),
+        timestamp: Utc::now().to_rfc3339(),
+    };
+    super::webhook_dispatch::dispatch_webhooks(state, job.account_id, "message.queued", &payload)
+        .await;
+
     Ok(())
 }

--- a/services/chorus-server/src/queue/worker.rs
+++ b/services/chorus-server/src/queue/worker.rs
@@ -129,6 +129,23 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
 
     match send_result {
         Ok(result) => {
+            // Dispatch message.sent (provider accepted)
+            let sent_payload = super::webhook_dispatch::WebhookPayload {
+                event: "message.sent".into(),
+                message_id: job.message_id,
+                channel: job.channel.clone(),
+                provider: Some(result.provider.clone()),
+                status: "sent".into(),
+                timestamp: Utc::now().to_rfc3339(),
+            };
+            super::webhook_dispatch::dispatch_webhooks(
+                state,
+                job.account_id,
+                "message.sent",
+                &sent_payload,
+            )
+            .await;
+
             repo.update_status(
                 job.message_id,
                 "delivered",

--- a/services/chorus-server/src/routes/batch.rs
+++ b/services/chorus-server/src/routes/batch.rs
@@ -111,7 +111,7 @@ pub async fn send_sms_batch(
             environment: message.environment.clone(),
             attempt: 0,
         };
-        if let Err(e) = crate::queue::enqueue::enqueue_job(&state, &job).await {
+        if let Err(e) = crate::queue::enqueue::notify(&state, &job).await {
             return Ok((
                 StatusCode::ACCEPTED,
                 Json(BatchSendResponse {
@@ -181,7 +181,7 @@ pub async fn send_email_batch(
             environment: message.environment.clone(),
             attempt: 0,
         };
-        if let Err(e) = crate::queue::enqueue::enqueue_job(&state, &job).await {
+        if let Err(e) = crate::queue::enqueue::notify(&state, &job).await {
             return Ok((
                 StatusCode::ACCEPTED,
                 Json(BatchSendResponse {

--- a/services/chorus-server/src/routes/email.rs
+++ b/services/chorus-server/src/routes/email.rs
@@ -53,7 +53,7 @@ pub async fn send_email(
         environment: message.environment.clone(),
         attempt: 0,
     };
-    crate::queue::enqueue::enqueue_job(&state, &job)
+    crate::queue::enqueue::notify(&state, &job)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 

--- a/services/chorus-server/src/routes/otp.rs
+++ b/services/chorus-server/src/routes/otp.rs
@@ -78,7 +78,7 @@ pub async fn send_otp(
         environment: _ctx.environment,
         attempt: 0,
     };
-    crate::queue::enqueue::enqueue_job(&state, &job)
+    crate::queue::enqueue::notify(&state, &job)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 

--- a/services/chorus-server/src/routes/sms.rs
+++ b/services/chorus-server/src/routes/sms.rs
@@ -59,7 +59,7 @@ pub async fn send_sms(
         environment: message.environment.clone(),
         attempt: 0,
     };
-    crate::queue::enqueue::enqueue_job(&state, &job)
+    crate::queue::enqueue::notify(&state, &job)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 

--- a/services/chorus-server/tests/api_test.rs
+++ b/services/chorus-server/tests/api_test.rs
@@ -573,3 +573,98 @@ async fn email_batch_exceeds_max_returns_400() {
 
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
+
+// ---------------------------------------------------------------------------
+// Webhook tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_create_returns_201_with_secret() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/webhooks")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::from(
+                    r#"{"url":"https://example.com/hook","events":["message.delivered"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body = response_body(resp).await;
+    assert!(body["id"].is_string());
+    assert_eq!(body["url"], "https://example.com/hook");
+    assert!(body["secret"].as_str().unwrap().len() >= 32);
+    assert_eq!(body["events"][0], "message.delivered");
+}
+
+#[tokio::test]
+async fn webhook_create_invalid_event_returns_400() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/webhooks")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::from(
+                    r#"{"url":"https://example.com/hook","events":["invalid.event"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn webhook_list_returns_200() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/webhooks")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_body(resp).await;
+    assert!(body.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn webhook_without_auth_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/webhooks")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    r#"{"url":"https://example.com/hook","events":["message.delivered"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
## Summary
- Dispatch `message.queued` webhook event when message enters queue (via `enqueue::notify()`)
- Dispatch `message.sent` webhook event when provider accepts message (before delivered)
- All 4 VALID_EVENTS now dispatched: queued → sent → delivered / failed
- Rename `enqueue::enqueue_job` → `enqueue::job`, `enqueue::enqueue_and_notify` → `enqueue::notify`
- Add 4 webhook integration tests (create, invalid event, list, auth)

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 110 tests pass (4 new webhook tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)