### PR TITLE
feat(server): Prometheus metrics, JSON logging, enhanced health

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,6 +2865,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,12 +2884,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -161,9 +161,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -197,9 +197,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -859,7 +859,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -881,7 +881,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -996,15 +996,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1186,12 +1185,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1242,9 +1241,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1296,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -1308,14 +1307,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1433,7 +1432,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -1605,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1637,9 +1636,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -1720,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -1828,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1927,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -2060,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2082,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2703,9 +2702,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -3041,9 +3040,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3054,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3064,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3074,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3087,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3130,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,7 +221,7 @@ dependencies = [
  "minijinja",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -256,6 +268,8 @@ dependencies = [
  "hickory-resolver",
  "hmac",
  "http-body-util",
+ "metrics",
+ "metrics-exporter-prometheus",
  "rand 0.8.5",
  "redis",
  "reqwest",
@@ -263,7 +277,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tower-http",
@@ -847,7 +861,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -870,7 +884,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1379,6 +1393,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1774,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +1872,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2184,6 +2277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,7 +2378,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2363,7 +2462,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2402,7 +2501,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2428,7 +2527,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -2530,11 +2629,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3021,6 +3140,28 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/services/chorus-server/Cargo.toml
+++ b/services/chorus-server/Cargo.toml
@@ -17,7 +17,7 @@ redis = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }

--- a/services/chorus-server/Cargo.toml
+++ b/services/chorus-server/Cargo.toml
@@ -30,6 +30,8 @@ hmac = { version = "0.12", features = ["std"] }
 reqwest = { workspace = true }
 async-trait = { workspace = true }
 hickory-resolver = { workspace = true }
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.16", default-features = false, features = ["http-listener"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -1,5 +1,6 @@
 use axum::routing::{delete, get, post};
 use axum::Router;
+use metrics_exporter_prometheus::PrometheusHandle;
 use sqlx::PgPool;
 use std::sync::Arc;
 
@@ -115,7 +116,15 @@ impl AppState {
 
 /// Build the Axum router with all routes and shared state.
 pub fn create_router(state: Arc<AppState>) -> Router {
-    Router::new()
+    create_router_with_metrics(state, None)
+}
+
+/// Build the Axum router with optional Prometheus metrics handle.
+pub fn create_router_with_metrics(
+    state: Arc<AppState>,
+    metrics_handle: Option<PrometheusHandle>,
+) -> Router {
+    let mut router = Router::new()
         .route("/health", get(routes::health::health))
         .route("/v1/sms/send", post(routes::sms::send_sms))
         .route("/v1/email/send", post(routes::email::send_email))
@@ -152,5 +161,15 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         .route("/internal/bounces", post(routes::internal::handle_bounce))
         .route("/internal/dns-check", get(routes::internal::dns_check))
-        .with_state(state)
+        .with_state(state);
+
+    if let Some(handle) = metrics_handle {
+        router = router.merge(
+            Router::new()
+                .route("/metrics", get(crate::metrics::handler))
+                .with_state(handle),
+        );
+    }
+
+    router
 }

--- a/services/chorus-server/src/lib.rs
+++ b/services/chorus-server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod auth;
 pub mod config;
 pub mod db;
+pub mod metrics;
 pub mod otp;
 pub mod queue;
 pub mod routes;

--- a/services/chorus-server/src/main.rs
+++ b/services/chorus-server/src/main.rs
@@ -1,4 +1,4 @@
-use chorus_server::app::{create_router, AppState};
+use chorus_server::app::{create_router_with_metrics, AppState};
 use chorus_server::config::Config;
 use std::sync::Arc;
 
@@ -12,6 +12,8 @@ async fn main() -> anyhow::Result<()> {
                 .unwrap_or_else(|_| "chorus_server=debug,tower_http=debug".into()),
         )
         .init();
+
+    let metrics_handle = chorus_server::metrics::setup();
 
     let config = Config::from_env();
 
@@ -35,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
         state.http_client().clone(),
     );
 
-    let app = create_router(state);
+    let app = create_router_with_metrics(state, Some(metrics_handle));
 
     let addr = format!("{}:{}", config.host, config.port);
     tracing::info!("chorus-server listening on {}", addr);

--- a/services/chorus-server/src/main.rs
+++ b/services/chorus-server/src/main.rs
@@ -16,9 +16,7 @@ async fn main() -> anyhow::Result<()> {
             .with_env_filter(env_filter)
             .init();
     } else {
-        tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
-            .init();
+        tracing_subscriber::fmt().with_env_filter(env_filter).init();
     }
 
     let metrics_handle = chorus_server::metrics::setup();

--- a/services/chorus-server/src/main.rs
+++ b/services/chorus-server/src/main.rs
@@ -6,12 +6,20 @@ use std::sync::Arc;
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "chorus_server=debug,tower_http=debug".into()),
-        )
-        .init();
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "chorus_server=debug,tower_http=debug".into());
+
+    let log_format = std::env::var("CHORUS_LOG_FORMAT").unwrap_or_default();
+    if log_format == "json" {
+        tracing_subscriber::fmt()
+            .json()
+            .with_env_filter(env_filter)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .init();
+    }
 
     let metrics_handle = chorus_server::metrics::setup();
 

--- a/services/chorus-server/src/metrics.rs
+++ b/services/chorus-server/src/metrics.rs
@@ -1,0 +1,19 @@
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+/// Install the Prometheus recorder and return a handle for rendering metrics.
+pub fn setup() -> PrometheusHandle {
+    PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install Prometheus recorder")
+}
+
+/// Axum handler that renders Prometheus metrics as text.
+pub async fn handler(handle: axum::extract::State<PrometheusHandle>) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
+        handle.render(),
+    )
+}

--- a/services/chorus-server/src/queue/webhook_dispatch.rs
+++ b/services/chorus-server/src/queue/webhook_dispatch.rs
@@ -119,14 +119,17 @@ async fn deliver_webhook(
     match result {
         Ok(resp) if resp.status().is_success() => {
             tracing::debug!(url, "webhook delivered");
+            metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "success").increment(1);
             true
         }
         Ok(resp) => {
             tracing::warn!(url, status = %resp.status(), "webhook delivery failed");
+            metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "failed").increment(1);
             false
         }
         Err(e) => {
             tracing::warn!(url, error = %e, "webhook HTTP error");
+            metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "error").increment(1);
             false
         }
     }

--- a/services/chorus-server/src/queue/worker.rs
+++ b/services/chorus-server/src/queue/worker.rs
@@ -46,7 +46,8 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
         .map_err(|e| anyhow::anyhow!("{e}"))?
         .ok_or_else(|| anyhow::anyhow!("message {} not found", job.message_id))?;
 
-    metrics::counter!("chorus_messages_processed_total", "channel" => job.channel.clone()).increment(1);
+    metrics::counter!("chorus_messages_processed_total", "channel" => job.channel.clone())
+        .increment(1);
 
     // Max retries exceeded → DLQ
     if job.attempt >= super::MAX_RETRIES {
@@ -187,7 +188,8 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            metrics::counter!("chorus_provider_errors_total", "channel" => job.channel.clone()).increment(1);
+            metrics::counter!("chorus_provider_errors_total", "channel" => job.channel.clone())
+                .increment(1);
 
             // Schedule retry with incremented attempt
             let retry_job = super::SendJob {

--- a/services/chorus-server/src/queue/worker.rs
+++ b/services/chorus-server/src/queue/worker.rs
@@ -46,6 +46,8 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
         .map_err(|e| anyhow::anyhow!("{e}"))?
         .ok_or_else(|| anyhow::anyhow!("message {} not found", job.message_id))?;
 
+    metrics::counter!("chorus_messages_processed_total", "channel" => job.channel.clone()).increment(1);
+
     // Max retries exceeded → DLQ
     if job.attempt >= super::MAX_RETRIES {
         repo.update_status(
@@ -82,6 +84,7 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
         )
         .await;
 
+        metrics::counter!("chorus_messages_total", "channel" => job.channel.clone(), "status" => "failed").increment(1);
         super::dead_letter::push_to_dlq(&state.redis, &job).await?;
         return Ok(());
     }
@@ -149,6 +152,8 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
+            metrics::counter!("chorus_messages_total", "channel" => job.channel.clone(), "status" => "delivered", "provider" => result.provider.clone()).increment(1);
+
             // Dispatch webhook
             let webhook_payload = super::webhook_dispatch::WebhookPayload {
                 event: "message.delivered".into(),
@@ -181,6 +186,8 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            metrics::counter!("chorus_provider_errors_total", "channel" => job.channel.clone()).increment(1);
 
             // Schedule retry with incremented attempt
             let retry_job = super::SendJob {

--- a/services/chorus-server/src/routes/health.rs
+++ b/services/chorus-server/src/routes/health.rs
@@ -1,43 +1,90 @@
 use axum::extract::State;
-use axum::http::StatusCode;
 use axum::Json;
 use serde::Serialize;
 use std::sync::Arc;
 
 use crate::app::AppState;
 
-/// Health check response.
+/// Health check response with component details.
 #[derive(Serialize)]
 pub struct HealthResponse {
     pub status: &'static str,
     pub version: &'static str,
+    pub components: Components,
+}
+
+/// Individual component health status.
+#[derive(Serialize)]
+pub struct Components {
+    pub database: ComponentStatus,
+    pub redis: ComponentStatus,
+    pub queue_depth: i64,
+}
+
+/// Status of a single component.
+#[derive(Serialize)]
+pub struct ComponentStatus {
+    pub status: &'static str,
 }
 
 /// Returns server health status after verifying database and Redis connectivity.
-pub async fn health(
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<HealthResponse>, (StatusCode, &'static str)> {
-    // Verify database connectivity (if pool is available)
-    if let Some(db) = &state.db {
-        sqlx::query("SELECT 1")
-            .execute(db)
-            .await
-            .map_err(|_| (StatusCode::SERVICE_UNAVAILABLE, "database unavailable"))?;
-    }
+pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
+    let db_status = check_database(&state).await;
+    let redis_status = check_redis(&state).await;
+    let queue_depth = get_queue_depth(&state).await;
 
-    // Verify Redis connectivity
-    let mut conn = state
-        .redis
-        .get_multiplexed_tokio_connection()
-        .await
-        .map_err(|_| (StatusCode::SERVICE_UNAVAILABLE, "redis unavailable"))?;
-    redis::cmd("PING")
-        .query_async::<String>(&mut conn)
-        .await
-        .map_err(|_| (StatusCode::SERVICE_UNAVAILABLE, "redis unavailable"))?;
+    let overall = if db_status == "ok" && redis_status == "ok" {
+        "ok"
+    } else {
+        "degraded"
+    };
 
-    Ok(Json(HealthResponse {
-        status: "ok",
+    // Report queue depth as a gauge metric
+    metrics::gauge!("chorus_queue_depth").set(queue_depth as f64);
+
+    Json(HealthResponse {
+        status: overall,
         version: env!("CARGO_PKG_VERSION"),
-    }))
+        components: Components {
+            database: ComponentStatus { status: db_status },
+            redis: ComponentStatus {
+                status: redis_status,
+            },
+            queue_depth,
+        },
+    })
+}
+
+async fn check_database(state: &AppState) -> &'static str {
+    if let Some(db) = &state.db {
+        match sqlx::query("SELECT 1").execute(db).await {
+            Ok(_) => "ok",
+            Err(_) => "unavailable",
+        }
+    } else {
+        "not_configured"
+    }
+}
+
+async fn check_redis(state: &AppState) -> &'static str {
+    let conn = state.redis.get_multiplexed_tokio_connection().await;
+    match conn {
+        Ok(mut c) => match redis::cmd("PING").query_async::<String>(&mut c).await {
+            Ok(_) => "ok",
+            Err(_) => "unavailable",
+        },
+        Err(_) => "unavailable",
+    }
+}
+
+async fn get_queue_depth(state: &AppState) -> i64 {
+    let conn = state.redis.get_multiplexed_tokio_connection().await;
+    match conn {
+        Ok(mut c) => redis::cmd("LLEN")
+            .arg(crate::queue::QUEUE_KEY)
+            .query_async::<i64>(&mut c)
+            .await
+            .unwrap_or(0),
+        Err(_) => -1,
+    }
 }


### PR DESCRIPTION
## Summary
- **Prometheus metrics** — `GET /metrics` endpoint with counters:
  - `chorus_messages_processed_total` (by channel)
  - `chorus_messages_total` (by channel, status, provider)
  - `chorus_provider_errors_total` (by channel)
  - `chorus_webhook_deliveries_total` (by event, status)
  - `chorus_queue_depth` (gauge)
- **JSON logging** — Set `CHORUS_LOG_FORMAT=json` for Loki-compatible structured output
- **Enhanced health** — `/health` returns component status (db, redis, queue_depth) + degraded detection

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 106 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)