### PR TITLE
feat(sdk): Python SDK with httpx REST client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -149,9 +149,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -185,9 +185,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -845,7 +845,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror",
  "tinyvec",
@@ -867,7 +867,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -982,15 +982,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1172,12 +1171,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1228,9 +1227,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1282,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -1294,14 +1293,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1545,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1577,9 +1576,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -1660,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -1753,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1834,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -1967,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1989,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2584,9 +2583,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -2909,9 +2908,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2922,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2932,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2942,9 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2955,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2998,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/sdks/python/.gitignore
+++ b/sdks/python/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+dist/
+*.egg-info/
+.venv/

--- a/sdks/python/chorus/__init__.py
+++ b/sdks/python/chorus/__init__.py
@@ -1,0 +1,7 @@
+"""Chorus CPaaS SDK — SMS, Email, OTP with smart routing."""
+
+from chorus.client import ChorusClient
+from chorus.errors import ChorusError
+
+__all__ = ["ChorusClient", "ChorusError"]
+__version__ = "0.2.0"

--- a/sdks/python/chorus/client.py
+++ b/sdks/python/chorus/client.py
@@ -1,0 +1,155 @@
+"""Chorus CPaaS client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from chorus.errors import ChorusError
+from chorus.types import (
+    BatchSendResponse,
+    BatchMessageResult,
+    CreateWebhookRequest,
+    Message,
+    OtpSendRequest,
+    OtpSendResponse,
+    OtpVerifyRequest,
+    OtpVerifyResponse,
+    SendEmailRequest,
+    SendResponse,
+    SendSmsRequest,
+    WebhookListItem,
+    WebhookResponse,
+)
+
+_DEFAULT_BASE_URL = "http://localhost:3000"
+
+
+class ChorusClient:
+    """Chorus CPaaS client."""
+
+    def __init__(self, api_key: str, *, base_url: str = _DEFAULT_BASE_URL) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._http = httpx.Client(
+            base_url=self._base_url,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+        self.sms = _SmsClient(self)
+        self.email = _EmailClient(self)
+        self.otp = _OtpClient(self)
+        self.messages = _MessageClient(self)
+        self.webhooks = _WebhookClient(self)
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._http.close()
+
+    def __enter__(self) -> ChorusClient:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    def _request(self, method: str, path: str, *, json: Any = None) -> Any:
+        resp = self._http.request(method, path, json=json)
+        if resp.status_code >= 400:
+            raise ChorusError(resp.status_code, resp.text)
+        if resp.status_code == 204 or not resp.content:
+            return None
+        return resp.json()
+
+
+def _to_json(req: Any) -> dict[str, Any]:
+    """Convert a dataclass to a JSON-safe dict, handling from_ → from."""
+    d: dict[str, Any] = {}
+    for k, v in req.__dict__.items():
+        if v is None:
+            continue
+        key = "from" if k == "from_" else k
+        d[key] = v
+    return d
+
+
+class _SmsClient:
+    def __init__(self, client: ChorusClient) -> None:
+        self._c = client
+
+    def send(self, req: SendSmsRequest) -> SendResponse:
+        data = self._c._request("POST", "/v1/sms/send", json=_to_json(req))
+        return SendResponse(**data)
+
+    def send_batch(self, recipients: list[dict[str, str]], from_: str | None = None) -> BatchSendResponse:
+        body: dict[str, Any] = {"recipients": recipients}
+        if from_:
+            body["from"] = from_
+        data = self._c._request("POST", "/v1/sms/send-batch", json=body)
+        return BatchSendResponse(
+            messages=[BatchMessageResult(**m) for m in data["messages"]],
+            error=data.get("error"),
+        )
+
+
+class _EmailClient:
+    def __init__(self, client: ChorusClient) -> None:
+        self._c = client
+
+    def send(self, req: SendEmailRequest) -> SendResponse:
+        data = self._c._request("POST", "/v1/email/send", json=_to_json(req))
+        return SendResponse(**data)
+
+    def send_batch(self, recipients: list[dict[str, str]], from_: str | None = None) -> BatchSendResponse:
+        body: dict[str, Any] = {"recipients": recipients}
+        if from_:
+            body["from"] = from_
+        data = self._c._request("POST", "/v1/email/send-batch", json=body)
+        return BatchSendResponse(
+            messages=[BatchMessageResult(**m) for m in data["messages"]],
+            error=data.get("error"),
+        )
+
+
+class _OtpClient:
+    def __init__(self, client: ChorusClient) -> None:
+        self._c = client
+
+    def send(self, req: OtpSendRequest) -> OtpSendResponse:
+        data = self._c._request("POST", "/v1/otp/send", json=_to_json(req))
+        return OtpSendResponse(**data)
+
+    def verify(self, req: OtpVerifyRequest) -> OtpVerifyResponse:
+        data = self._c._request("POST", "/v1/otp/verify", json=_to_json(req))
+        return OtpVerifyResponse(**data)
+
+
+class _MessageClient:
+    def __init__(self, client: ChorusClient) -> None:
+        self._c = client
+
+    def get(self, id: str) -> Message:
+        data = self._c._request("GET", f"/v1/messages/{id}")
+        return Message(**data)
+
+    def list(self, *, limit: int = 20, offset: int = 0) -> list[Message]:
+        data = self._c._request("GET", f"/v1/messages?limit={limit}&offset={offset}")
+        return [Message(**m) for m in data]
+
+
+class _WebhookClient:
+    def __init__(self, client: ChorusClient) -> None:
+        self._c = client
+
+    def create(self, req: CreateWebhookRequest) -> WebhookResponse:
+        data = self._c._request("POST", "/v1/webhooks", json=_to_json(req))
+        return WebhookResponse(**data)
+
+    def list(self) -> list[WebhookListItem]:
+        data = self._c._request("GET", "/v1/webhooks")
+        return [WebhookListItem(**w) for w in data]
+
+    def delete(self, id: str) -> None:
+        self._c._request("DELETE", f"/v1/webhooks/{id}")

--- a/sdks/python/chorus/errors.py
+++ b/sdks/python/chorus/errors.py
@@ -1,0 +1,10 @@
+"""Error types for the Chorus SDK."""
+
+
+class ChorusError(Exception):
+    """Raised when the Chorus API returns an error response."""
+
+    def __init__(self, status: int, body: str) -> None:
+        super().__init__(f"Chorus API error ({status}): {body}")
+        self.status = status
+        self.body = body

--- a/sdks/python/chorus/types.py
+++ b/sdks/python/chorus/types.py
@@ -1,0 +1,108 @@
+"""Request and response types for the Chorus API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+# --- Request types ---
+
+
+@dataclass
+class SendSmsRequest:
+    to: str
+    body: str
+    from_: str | None = field(default=None, metadata={"alias": "from"})
+
+
+@dataclass
+class SendEmailRequest:
+    to: str
+    subject: str
+    body: str
+    from_: str | None = field(default=None, metadata={"alias": "from"})
+
+
+@dataclass
+class OtpSendRequest:
+    to: str
+    app_name: str | None = None
+
+
+@dataclass
+class OtpVerifyRequest:
+    to: str
+    code: str
+
+
+@dataclass
+class CreateWebhookRequest:
+    url: str
+    events: list[str]
+
+
+# --- Response types ---
+
+
+@dataclass
+class SendResponse:
+    message_id: str
+    status: str
+
+
+@dataclass
+class BatchMessageResult:
+    message_id: str
+    to: str
+    status: str
+
+
+@dataclass
+class BatchSendResponse:
+    messages: list[BatchMessageResult]
+    error: str | None = None
+
+
+@dataclass
+class OtpSendResponse:
+    message_id: str
+    expires_in: int
+
+
+@dataclass
+class OtpVerifyResponse:
+    valid: bool
+
+
+@dataclass
+class Message:
+    id: str
+    account_id: str
+    channel: str
+    recipient: str
+    body: str
+    status: str
+    environment: str
+    created_at: str
+    provider: str | None = None
+    sender: str | None = None
+    subject: str | None = None
+    error_message: str | None = None
+    delivered_at: str | None = None
+
+
+@dataclass
+class WebhookResponse:
+    id: str
+    url: str
+    secret: str
+    events: list[str]
+    created_at: str
+
+
+@dataclass
+class WebhookListItem:
+    id: str
+    url: str
+    events: list[str]
+    created_at: str

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chorus-sdk"
+version = "0.2.0"
+description = "Official Python SDK for Chorus CPaaS — SMS, Email, OTP"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+keywords = ["sms", "email", "otp", "cpaas", "messaging", "chorus"]
+dependencies = ["httpx>=0.27"]
+
+[project.urls]
+Repository = "https://github.com/cntm-labs/chorus"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,0 +1,114 @@
+"""Tests for ChorusClient using pytest-httpserver."""
+
+import pytest
+from chorus import ChorusClient, ChorusError
+from chorus.types import (
+    CreateWebhookRequest,
+    OtpSendRequest,
+    OtpVerifyRequest,
+    SendEmailRequest,
+    SendSmsRequest,
+)
+from pytest_httpserver import HTTPServer
+
+
+@pytest.fixture()
+def server(httpserver: HTTPServer) -> HTTPServer:
+    httpserver.expect_request("/v1/sms/send", method="POST").respond_with_json(
+        {"message_id": "msg-1", "status": "queued"}, status=202
+    )
+    httpserver.expect_request("/v1/email/send", method="POST").respond_with_json(
+        {"message_id": "msg-2", "status": "queued"}, status=202
+    )
+    httpserver.expect_request("/v1/sms/send-batch", method="POST").respond_with_json(
+        {"messages": [{"message_id": "msg-3", "to": "+111", "status": "queued"}]}, status=202
+    )
+    httpserver.expect_request("/v1/otp/send", method="POST").respond_with_json(
+        {"message_id": "msg-4", "expires_in": 300}, status=202
+    )
+    httpserver.expect_request("/v1/otp/verify", method="POST").respond_with_json(
+        {"valid": True}
+    )
+    httpserver.expect_request("/v1/messages/msg-1", method="GET").respond_with_json(
+        {
+            "id": "msg-1", "account_id": "acc-1", "channel": "sms",
+            "recipient": "+111", "body": "hi", "status": "delivered",
+            "environment": "live", "created_at": "2026-01-01T00:00:00Z",
+        }
+    )
+    httpserver.expect_request("/v1/messages", method="GET").respond_with_json([])
+    httpserver.expect_request("/v1/webhooks", method="POST").respond_with_json(
+        {
+            "id": "wh-1", "url": "https://example.com/hook",
+            "secret": "abc123", "events": ["message.delivered"],
+            "created_at": "2026-01-01T00:00:00Z",
+        },
+        status=201,
+    )
+    httpserver.expect_request("/v1/webhooks", method="GET").respond_with_json([])
+    httpserver.expect_request("/v1/webhooks/wh-1", method="DELETE").respond_with_data(
+        "", status=204
+    )
+    return httpserver
+
+
+@pytest.fixture()
+def client(server: HTTPServer) -> ChorusClient:
+    return ChorusClient("ch_test_xxx", base_url=server.url_for(""))
+
+
+def test_send_sms(client: ChorusClient) -> None:
+    res = client.sms.send(SendSmsRequest(to="+111", body="hi"))
+    assert res.message_id == "msg-1"
+    assert res.status == "queued"
+
+
+def test_send_email(client: ChorusClient) -> None:
+    res = client.email.send(SendEmailRequest(to="a@b.com", subject="Hi", body="Hello"))
+    assert res.message_id == "msg-2"
+
+
+def test_send_sms_batch(client: ChorusClient) -> None:
+    res = client.sms.send_batch([{"to": "+111", "body": "hi"}])
+    assert len(res.messages) == 1
+
+
+def test_send_otp(client: ChorusClient) -> None:
+    res = client.otp.send(OtpSendRequest(to="+111"))
+    assert res.expires_in == 300
+
+
+def test_verify_otp(client: ChorusClient) -> None:
+    res = client.otp.verify(OtpVerifyRequest(to="+111", code="123456"))
+    assert res.valid is True
+
+
+def test_get_message(client: ChorusClient) -> None:
+    msg = client.messages.get("msg-1")
+    assert msg.id == "msg-1"
+    assert msg.status == "delivered"
+
+
+def test_list_messages(client: ChorusClient) -> None:
+    msgs = client.messages.list()
+    assert msgs == []
+
+
+def test_create_webhook(client: ChorusClient) -> None:
+    wh = client.webhooks.create(CreateWebhookRequest(url="https://example.com/hook", events=["message.delivered"]))
+    assert wh.id == "wh-1"
+    assert wh.secret == "abc123"
+
+
+def test_delete_webhook(client: ChorusClient) -> None:
+    client.webhooks.delete("wh-1")
+
+
+def test_api_error(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/v1/sms/send", method="POST").respond_with_data(
+        "Unauthorized", status=401
+    )
+    c = ChorusClient("bad_key", base_url=httpserver.url_for(""))
+    with pytest.raises(ChorusError) as exc_info:
+        c.sms.send(SendSmsRequest(to="+111", body="hi"))
+    assert exc_info.value.status == 401


### PR DESCRIPTION
## Summary
- Adds `sdks/python/` (`chorus-sdk` on PyPI) — Python 3.10+ SDK using httpx
- ChorusClient with sub-clients: `sms`, `email`, `otp`, `messages`, `webhooks`
- Context manager support: `with ChorusClient(key) as c:`
- Dataclass request/response types
- ChorusError with status code and body

## Test plan
- [x] `pytest` — 10 tests pass using pytest-httpserver

🤖 Generated with [Claude Code](https://claude.com/claude-code)