### PR TITLE
feat(server): add admin panel API endpoints

### DIFF
--- a/docs/plans/2026-04-17-admin-panel-api.md
+++ b/docs/plans/2026-04-17-admin-panel-api.md
@@ -1,0 +1,1075 @@
+# Admin Panel API Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add admin-only REST API endpoints for account management, provider config, DLQ, message inspection, billing, and webhooks — enabling Strata dashboard to manage Chorus without direct DB access.
+
+**Architecture:** New `AdminContext` extractor authenticated by `ch_admin_` API keys stored in a dedicated `admin_keys` table. All admin routes live under `/admin/` prefix with a shared admin auth middleware layer. Each feature module adds repository trait methods + route handlers following existing patterns.
+
+**Tech Stack:** Rust, Axum, sqlx, Redis, serde, uuid, chrono
+
+**Closes:** #34, #35, #36, #37, #38, #39
+
+---
+
+### Task 1: Create Admin Auth Migration
+
+**Files:**
+- Create: `services/chorus-server/src/db/migrations/005_create_admin_keys.sql`
+
+**Step 1: Write migration**
+
+```sql
+CREATE TABLE admin_keys (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    key_hash TEXT NOT NULL UNIQUE,
+    key_prefix TEXT NOT NULL,
+    is_revoked BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_admin_keys_key_hash ON admin_keys (key_hash);
+```
+
+**Step 2: Run `cargo check -p chorus-server`**
+
+Expected: compiles (migration is SQL, not compiled, but verify no syntax issues at startup later).
+
+**Step 3: Commit**
+
+```bash
+git add services/chorus-server/src/db/migrations/005_create_admin_keys.sql
+git commit -m "feat(server): add admin_keys migration"
+```
+
+---
+
+### Task 2: Create AdminContext Extractor
+
+**Files:**
+- Create: `services/chorus-server/src/auth/admin.rs`
+- Modify: `services/chorus-server/src/auth/mod.rs`
+
+**Step 1: Create admin auth extractor**
+
+Create `services/chorus-server/src/auth/admin.rs`:
+```rust
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+
+/// Authenticated admin context extracted from an admin API key.
+#[derive(Debug, Clone)]
+pub struct AdminContext {
+    /// The admin key ID used to authenticate.
+    pub key_id: Uuid,
+}
+
+impl FromRequestParts<Arc<AppState>> for AdminContext {
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        let header = parts
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .ok_or((StatusCode::UNAUTHORIZED, "missing authorization header"))?;
+
+        let key = header
+            .strip_prefix("Bearer ")
+            .ok_or((StatusCode::UNAUTHORIZED, "invalid authorization format"))?;
+
+        if !key.starts_with("ch_admin_") {
+            return Err((StatusCode::UNAUTHORIZED, "invalid admin key format"));
+        }
+
+        let hash = hex::encode(Sha256::digest(key.as_bytes()));
+
+        let admin_key = state
+            .admin_key_repo()
+            .find_by_hash(&hash)
+            .await
+            .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "database error"))?
+            .ok_or((StatusCode::UNAUTHORIZED, "invalid admin key"))?;
+
+        if admin_key.is_revoked {
+            return Err((StatusCode::UNAUTHORIZED, "admin key is revoked"));
+        }
+
+        Ok(AdminContext {
+            key_id: admin_key.id,
+        })
+    }
+}
+```
+
+**Step 2: Export admin module**
+
+In `services/chorus-server/src/auth/mod.rs`, add:
+```rust
+pub mod admin;
+```
+
+**Step 3: Run `cargo check -p chorus-server`**
+
+Expected: will fail — `admin_key_repo()` and `AdminKey` type don't exist yet. That's expected; we'll fix in next tasks.
+
+**Step 4: Commit**
+
+```bash
+git add services/chorus-server/src/auth/
+git commit -m "feat(server): add AdminContext extractor (WIP — needs repo)"
+```
+
+---
+
+### Task 3: Add AdminKey Type + Repository Trait
+
+**Files:**
+- Modify: `services/chorus-server/src/db/mod.rs`
+- Modify: `services/chorus-server/src/db/postgres.rs`
+- Modify: `services/chorus-server/src/app.rs`
+
+**Step 1: Add AdminKey type and trait to db/mod.rs**
+
+Add after existing types:
+```rust
+/// An admin API key for dashboard access.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AdminKey {
+    pub id: Uuid,
+    pub name: String,
+    pub key_prefix: String,
+    pub is_revoked: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Repository for admin key operations.
+#[async_trait::async_trait]
+pub trait AdminKeyRepository: Send + Sync {
+    /// Find an admin key by its SHA-256 hash.
+    async fn find_by_hash(&self, hash: &str) -> Result<Option<AdminKey>, DbError>;
+}
+```
+
+**Step 2: Implement in postgres.rs**
+
+Add at the end of `postgres.rs`:
+```rust
+#[async_trait]
+impl AdminKeyRepository for PgRepository {
+    async fn find_by_hash(&self, hash: &str) -> Result<Option<AdminKey>, DbError> {
+        let key = sqlx::query_as::<_, AdminKey>(
+            "SELECT id, name, key_prefix, is_revoked, created_at
+             FROM admin_keys WHERE key_hash = $1",
+        )
+        .bind(hash)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(key)
+    }
+}
+```
+
+**Step 3: Add admin_key_repo() to AppState**
+
+In `app.rs`, add a method to `AppState` and the necessary field. Follow the existing pattern used by `account_repo()`, `message_repo()`, etc.
+
+Add to `AppState` struct:
+```rust
+admin_key_repo: Arc<dyn AdminKeyRepository>,
+```
+
+Add getter:
+```rust
+pub fn admin_key_repo(&self) -> Arc<dyn AdminKeyRepository> {
+    Arc::clone(&self.admin_key_repo)
+}
+```
+
+Initialize in `AppState::new()` (or wherever AppState is constructed):
+```rust
+admin_key_repo: Arc::new(PgRepository::new(pool.clone())),
+```
+
+**Step 4: Run `cargo check -p chorus-server`**
+
+Expected: compiles cleanly (AdminContext extractor can now resolve).
+
+**Step 5: Commit**
+
+```bash
+git add services/chorus-server/src/db/ services/chorus-server/src/app.rs
+git commit -m "feat(server): add AdminKey type, repository trait, and AppState wiring"
+```
+
+---
+
+### Task 4: Create Admin Routes Module + Wire into Router
+
+**Files:**
+- Create: `services/chorus-server/src/routes/admin/mod.rs`
+- Create: `services/chorus-server/src/routes/admin/accounts.rs`
+- Modify: `services/chorus-server/src/routes/mod.rs`
+- Modify: `services/chorus-server/src/app.rs`
+
+**Step 1: Create admin routes module**
+
+Create `services/chorus-server/src/routes/admin/mod.rs`:
+```rust
+pub mod accounts;
+
+use axum::routing::{delete, get, patch, post};
+use axum::Router;
+use std::sync::Arc;
+
+use crate::app::AppState;
+
+/// Build the admin sub-router with all admin endpoints.
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        // Account Management (#34)
+        .route("/accounts", get(accounts::list))
+        .route("/accounts/{id}", get(accounts::detail))
+        .route("/accounts", post(accounts::create))
+        .route("/accounts/{id}", patch(accounts::update))
+        .route("/accounts/{id}", delete(accounts::soft_delete))
+}
+```
+
+**Step 2: Create placeholder accounts handler**
+
+Create `services/chorus-server/src/routes/admin/accounts.rs`:
+```rust
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::admin::AdminContext;
+
+#[derive(Serialize)]
+pub struct AccountListItem {
+    pub id: Uuid,
+    pub name: String,
+    pub owner_email: String,
+    pub is_active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// `GET /admin/accounts` — list all accounts.
+pub async fn list(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+) -> Result<Json<Vec<AccountListItem>>, (StatusCode, String)> {
+    let accounts = state
+        .admin_repo()
+        .list_accounts()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(accounts))
+}
+
+#[derive(Serialize)]
+pub struct AccountDetail {
+    pub id: Uuid,
+    pub name: String,
+    pub owner_email: String,
+    pub is_active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub key_count: i64,
+    pub message_count: i64,
+}
+
+/// `GET /admin/accounts/{id}` — account detail with usage stats.
+pub async fn detail(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+) -> Result<Json<AccountDetail>, (StatusCode, String)> {
+    let account = state
+        .admin_repo()
+        .get_account_detail(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "account not found".into()))?;
+
+    Ok(Json(account))
+}
+
+#[derive(Deserialize)]
+pub struct CreateAccountRequest {
+    pub name: String,
+    pub owner_email: String,
+}
+
+/// `POST /admin/accounts` — create a new account.
+pub async fn create(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Json(body): Json<CreateAccountRequest>,
+) -> Result<(StatusCode, Json<AccountListItem>), (StatusCode, String)> {
+    let account = state
+        .admin_repo()
+        .create_account(&body.name, &body.owner_email)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(account)))
+}
+
+#[derive(Deserialize)]
+pub struct UpdateAccountRequest {
+    pub is_active: Option<bool>,
+    pub name: Option<String>,
+}
+
+/// `PATCH /admin/accounts/{id}` — update account fields.
+pub async fn update(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateAccountRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .admin_repo()
+        .update_account(id, body.is_active, body.name.as_deref())
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /admin/accounts/{id}` — soft-delete account.
+pub async fn soft_delete(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .admin_repo()
+        .deactivate_account(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+```
+
+**Step 3: Export admin module in routes/mod.rs**
+
+Add to `services/chorus-server/src/routes/mod.rs`:
+```rust
+pub mod admin;
+```
+
+**Step 4: Wire admin router into app.rs**
+
+In `create_router_with_metrics`, after the main router `.with_state(state)` call, add the admin sub-router *before* the metrics middleware layer:
+```rust
+    let mut router = Router::new()
+        // ... all existing routes ...
+        .nest("/admin", routes::admin::router())
+        .with_state(state)
+        .layer(axum_middleware::from_fn(crate::middleware::metrics::track));
+```
+
+**Step 5: Run `cargo check -p chorus-server`**
+
+Expected: will fail — `admin_repo()` doesn't exist yet. Commit WIP.
+
+**Step 6: Commit**
+
+```bash
+git add services/chorus-server/src/routes/ services/chorus-server/src/app.rs
+git commit -m "feat(server): add admin routes module with account endpoints (WIP — needs repo)"
+```
+
+---
+
+### Task 5: Create AdminRepository Trait + Implementation (#34)
+
+**Files:**
+- Create: `services/chorus-server/src/db/admin.rs`
+- Modify: `services/chorus-server/src/db/mod.rs`
+- Modify: `services/chorus-server/src/app.rs`
+
+**Step 1: Create AdminRepository trait and Pg implementation**
+
+Create `services/chorus-server/src/db/admin.rs`:
+```rust
+use async_trait::async_trait;
+use sqlx::PgPool;
+use std::time::Instant;
+use uuid::Uuid;
+
+use super::DbError;
+use crate::routes::admin::accounts::{AccountDetail, AccountListItem};
+
+/// Repository for admin-only cross-account queries.
+#[async_trait]
+pub trait AdminRepository: Send + Sync {
+    /// List all accounts.
+    async fn list_accounts(&self) -> Result<Vec<AccountListItem>, DbError>;
+    /// Get account detail with usage stats.
+    async fn get_account_detail(&self, id: Uuid) -> Result<Option<AccountDetail>, DbError>;
+    /// Create a new account.
+    async fn create_account(&self, name: &str, email: &str) -> Result<AccountListItem, DbError>;
+    /// Update account fields.
+    async fn update_account(
+        &self,
+        id: Uuid,
+        is_active: Option<bool>,
+        name: Option<&str>,
+    ) -> Result<(), DbError>;
+    /// Deactivate (soft-delete) an account.
+    async fn deactivate_account(&self, id: Uuid) -> Result<(), DbError>;
+}
+
+/// PostgreSQL implementation.
+pub struct PgAdminRepository {
+    pool: PgPool,
+}
+
+impl PgAdminRepository {
+    /// Create a new admin repository.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl AdminRepository for PgAdminRepository {
+    async fn list_accounts(&self) -> Result<Vec<AccountListItem>, DbError> {
+        let rows = sqlx::query_as::<_, AccountListItem>(
+            "SELECT id, name, owner_email, is_active, created_at FROM accounts ORDER BY created_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(rows)
+    }
+
+    async fn get_account_detail(&self, id: Uuid) -> Result<Option<AccountDetail>, DbError> {
+        let row = sqlx::query_as::<_, AccountDetail>(
+            "SELECT a.id, a.name, a.owner_email, a.is_active, a.created_at, a.updated_at,
+                    (SELECT COUNT(*) FROM api_keys WHERE account_id = a.id) AS key_count,
+                    (SELECT COUNT(*) FROM messages WHERE account_id = a.id) AS message_count
+             FROM accounts a WHERE a.id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(row)
+    }
+
+    async fn create_account(&self, name: &str, email: &str) -> Result<AccountListItem, DbError> {
+        let row = sqlx::query_as::<_, AccountListItem>(
+            "INSERT INTO accounts (name, owner_email) VALUES ($1, $2)
+             RETURNING id, name, owner_email, is_active, created_at",
+        )
+        .bind(name)
+        .bind(email)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(row)
+    }
+
+    async fn update_account(
+        &self,
+        id: Uuid,
+        is_active: Option<bool>,
+        name: Option<&str>,
+    ) -> Result<(), DbError> {
+        sqlx::query(
+            "UPDATE accounts SET
+                is_active = COALESCE($1, is_active),
+                name = COALESCE($2, name),
+                updated_at = now()
+             WHERE id = $3",
+        )
+        .bind(is_active)
+        .bind(name)
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(())
+    }
+
+    async fn deactivate_account(&self, id: Uuid) -> Result<(), DbError> {
+        sqlx::query("UPDATE accounts SET is_active = false, updated_at = now() WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(())
+    }
+}
+```
+
+**Step 2: Export in db/mod.rs**
+
+Add:
+```rust
+pub mod admin;
+pub use admin::{AdminRepository, PgAdminRepository};
+```
+
+**Step 3: Add admin_repo() to AppState**
+
+Add field, getter, and initialization following the same pattern as other repos.
+
+**Step 4: Run `cargo check -p chorus-server`**
+
+Expected: compiles cleanly. Note: `AccountListItem` and `AccountDetail` need `sqlx::FromRow` derive added in accounts.rs.
+
+**Step 5: Run `cargo test -p chorus-server`**
+
+Expected: all existing tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add services/chorus-server/src/db/ services/chorus-server/src/app.rs services/chorus-server/src/routes/admin/
+git commit -m "feat(server): add AdminRepository + account management endpoints (closes #34)"
+```
+
+---
+
+### Task 6: Admin Provider Config Endpoints (#35)
+
+**Files:**
+- Create: `services/chorus-server/src/routes/admin/providers.rs`
+- Modify: `services/chorus-server/src/routes/admin/mod.rs`
+- Modify: `services/chorus-server/src/db/admin.rs`
+
+**Step 1: Add provider admin methods to AdminRepository trait**
+
+Add to trait in `db/admin.rs`:
+```rust
+    /// List all provider configs across accounts.
+    async fn list_all_provider_configs(&self) -> Result<Vec<AdminProviderConfig>, DbError>;
+    /// Get provider health summary (error rate from recent delivery events).
+    async fn get_provider_health(&self, id: Uuid) -> Result<Option<ProviderHealth>, DbError>;
+    /// Update provider config (priority, is_active).
+    async fn update_provider_config(
+        &self,
+        id: Uuid,
+        priority: Option<i32>,
+        is_active: Option<bool>,
+    ) -> Result<(), DbError>;
+    /// Disable a provider across all accounts (outage scenario).
+    async fn disable_provider_by_name(&self, provider: &str) -> Result<u64, DbError>;
+```
+
+**Step 2: Define response types**
+
+In `routes/admin/providers.rs`:
+```rust
+#[derive(Serialize, sqlx::FromRow)]
+pub struct AdminProviderConfig {
+    pub id: Uuid,
+    pub account_id: Uuid,
+    pub channel: String,
+    pub provider: String,
+    pub priority: i32,
+    pub is_active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Serialize)]
+pub struct ProviderHealth {
+    pub id: Uuid,
+    pub provider: String,
+    pub total_sent: i64,
+    pub total_errors: i64,
+    pub error_rate: f64,
+    pub last_success: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_error: Option<chrono::DateTime<chrono::Utc>>,
+}
+```
+
+**Step 3: Implement handlers**
+
+Endpoints:
+- `GET /admin/providers` — list_all
+- `GET /admin/providers/{id}/health` — health
+- `PATCH /admin/providers/{id}` — update
+- `POST /admin/providers/disable` — bulk disable by provider name
+
+**Step 4: Implement Pg queries**
+
+Health query joins `messages` + `delivery_events` tables to compute error rate:
+```sql
+SELECT pc.id, pc.provider,
+       COUNT(CASE WHEN m.status = 'delivered' THEN 1 END) AS total_sent,
+       COUNT(CASE WHEN m.status = 'failed' THEN 1 END) AS total_errors,
+       MAX(CASE WHEN m.status = 'delivered' THEN m.delivered_at END) AS last_success,
+       MAX(CASE WHEN de.status = 'failed_attempt' THEN de.created_at END) AS last_error
+FROM provider_configs pc
+LEFT JOIN messages m ON m.provider = pc.provider AND m.account_id = pc.account_id
+LEFT JOIN delivery_events de ON de.message_id = m.id
+WHERE pc.id = $1
+GROUP BY pc.id, pc.provider
+```
+
+**Step 5: Wire routes**
+
+In `routes/admin/mod.rs`, add:
+```rust
+pub mod providers;
+```
+
+Add routes:
+```rust
+    .route("/providers", get(providers::list_all))
+    .route("/providers/{id}/health", get(providers::health))
+    .route("/providers/{id}", patch(providers::update))
+    .route("/providers/disable", post(providers::bulk_disable))
+```
+
+**Step 6: Run `cargo check -p chorus-server`**
+
+**Step 7: Commit**
+
+```bash
+git add services/chorus-server/src/
+git commit -m "feat(server): add admin provider config + health endpoints (closes #35)"
+```
+
+---
+
+### Task 7: Admin DLQ Management Endpoints (#36)
+
+**Files:**
+- Create: `services/chorus-server/src/routes/admin/dlq.rs`
+- Modify: `services/chorus-server/src/routes/admin/mod.rs`
+- Modify: `services/chorus-server/src/db/admin.rs`
+
+**Step 1: Add DLQ methods to AdminRepository**
+
+DLQ lives in Redis (`chorus:dead_letters` list). We need methods that:
+1. Read DLQ entries from Redis (LRANGE)
+2. Look up message details from PostgreSQL
+3. Re-enqueue by removing from DLQ and pushing to main queue
+
+Add to trait:
+```rust
+    /// List DLQ messages with pagination.
+    async fn list_dlq_messages(
+        &self,
+        limit: i64,
+        offset: i64,
+        channel: Option<&str>,
+        account_id: Option<Uuid>,
+    ) -> Result<Vec<DlqMessage>, DbError>;
+    /// Get DLQ message detail with full retry history.
+    async fn get_dlq_message_detail(&self, message_id: Uuid) -> Result<Option<DlqMessageDetail>, DbError>;
+```
+
+**Step 2: DLQ Redis operations**
+
+Create helper functions in a new file or in `routes/admin/dlq.rs` for:
+- `list_dlq` — LRANGE on `chorus:dead_letters`, parse JSON, join with DB
+- `retry_single` — LREM from DLQ, reset attempt to 0, LPUSH to main queue
+- `retry_batch` — same for multiple message IDs
+- `purge_single` — LREM from DLQ
+- `purge_all` — DEL the entire DLQ key (with date filter = scan + LREM)
+
+**Step 3: Response types**
+
+```rust
+#[derive(Serialize)]
+pub struct DlqMessage {
+    pub message_id: Uuid,
+    pub account_id: Uuid,
+    pub channel: String,
+    pub recipient: String,
+    pub status: String,
+    pub attempts: i32,
+    pub error_message: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Serialize)]
+pub struct DlqMessageDetail {
+    pub message: DlqMessage,
+    pub delivery_events: Vec<crate::db::DeliveryEvent>,
+}
+```
+
+**Step 4: Implement handlers**
+
+Endpoints:
+- `GET /admin/dlq` — list (query params: limit, offset, channel, account_id)
+- `GET /admin/dlq/{message_id}` — detail with retry history
+- `POST /admin/dlq/{message_id}/retry` — re-enqueue single
+- `POST /admin/dlq/retry-batch` — re-enqueue multiple (JSON body with message_ids)
+- `DELETE /admin/dlq/{message_id}` — purge single
+- `DELETE /admin/dlq/purge` — purge old (query param: older_than_days)
+
+**Step 5: Wire routes**
+
+```rust
+pub mod dlq;
+```
+
+```rust
+    .route("/dlq", get(dlq::list))
+    .route("/dlq/{message_id}", get(dlq::detail))
+    .route("/dlq/{message_id}/retry", post(dlq::retry_single))
+    .route("/dlq/retry-batch", post(dlq::retry_batch))
+    .route("/dlq/{message_id}", delete(dlq::purge_single))
+    .route("/dlq/purge", delete(dlq::purge_all))
+```
+
+**Step 6: Run `cargo check -p chorus-server` + `cargo test -p chorus-server`**
+
+**Step 7: Commit**
+
+```bash
+git add services/chorus-server/src/
+git commit -m "feat(server): add admin DLQ management endpoints (closes #36)"
+```
+
+---
+
+### Task 8: Admin Message Inspector Endpoints (#37)
+
+**Files:**
+- Create: `services/chorus-server/src/routes/admin/messages.rs`
+- Modify: `services/chorus-server/src/routes/admin/mod.rs`
+- Modify: `services/chorus-server/src/db/admin.rs`
+
+**Step 1: Add message search to AdminRepository**
+
+```rust
+    /// Search messages across all accounts with filters.
+    async fn search_messages(&self, filters: &MessageSearchFilters) -> Result<Vec<Message>, DbError>;
+    /// Get message detail with delivery timeline.
+    async fn get_message_detail(&self, id: Uuid) -> Result<Option<MessageDetail>, DbError>;
+```
+
+**Step 2: Define filter struct**
+
+```rust
+#[derive(Deserialize)]
+pub struct MessageSearchFilters {
+    pub account_id: Option<Uuid>,
+    pub channel: Option<String>,
+    pub status: Option<String>,
+    pub provider: Option<String>,
+    pub date_from: Option<chrono::DateTime<chrono::Utc>>,
+    pub date_to: Option<chrono::DateTime<chrono::Utc>>,
+    pub recipient: Option<String>,       // partial match with ILIKE
+    pub min_cost: Option<i64>,           // microdollars
+    pub max_cost: Option<i64>,
+    pub limit: Option<i64>,              // default 50
+    pub offset: Option<i64>,             // default 0
+}
+```
+
+**Step 3: Implement dynamic SQL query**
+
+Build query with optional WHERE clauses. Use sqlx's query builder or manual string building with bind parameters:
+
+```rust
+async fn search_messages(&self, f: &MessageSearchFilters) -> Result<Vec<Message>, DbError> {
+    let mut query = String::from("SELECT * FROM messages WHERE 1=1");
+    // Dynamically append conditions based on which filters are Some
+    // Use positional parameters ($1, $2, etc.)
+    // ORDER BY created_at DESC LIMIT $N OFFSET $M
+}
+```
+
+**Step 4: Message detail includes delivery events**
+
+```rust
+#[derive(Serialize)]
+pub struct MessageDetail {
+    pub message: Message,
+    pub delivery_events: Vec<DeliveryEvent>,
+}
+```
+
+Query: fetch message (no account_id filter) + delivery events.
+
+**Step 5: Handlers**
+
+- `GET /admin/messages` — search (all filters as query params)
+- `GET /admin/messages/{id}` — detail with timeline
+
+**Step 6: Wire routes**
+
+```rust
+pub mod messages;
+```
+
+```rust
+    .route("/messages", get(messages::search))
+    .route("/messages/{id}", get(messages::detail))
+```
+
+**Step 7: Run `cargo check -p chorus-server`**
+
+**Step 8: Commit**
+
+```bash
+git add services/chorus-server/src/
+git commit -m "feat(server): add admin message inspector endpoints (closes #37)"
+```
+
+---
+
+### Task 9: Admin Billing Endpoints (#38)
+
+**Files:**
+- Create: `services/chorus-server/src/routes/admin/billing.rs`
+- Modify: `services/chorus-server/src/routes/admin/mod.rs`
+- Modify: `services/chorus-server/src/db/admin.rs`
+
+**Step 1: Add billing admin methods to AdminRepository**
+
+```rust
+    /// List all accounts with billing status.
+    async fn list_billing_accounts(&self) -> Result<Vec<BillingAccountSummary>, DbError>;
+    /// Override an account's subscription plan.
+    async fn override_plan(&self, account_id: Uuid, plan_slug: &str) -> Result<(), DbError>;
+    /// Adjust usage counters.
+    async fn adjust_usage(
+        &self,
+        account_id: Uuid,
+        sms_delta: Option<i32>,
+        email_delta: Option<i32>,
+    ) -> Result<(), DbError>;
+    /// Generate billing report.
+    async fn billing_report(&self) -> Result<BillingReport, DbError>;
+```
+
+**Step 2: Response types**
+
+```rust
+#[derive(Serialize)]
+pub struct BillingAccountSummary {
+    pub account_id: Uuid,
+    pub account_name: String,
+    pub plan_slug: String,
+    pub status: String,
+    pub sms_sent: i32,
+    pub sms_quota: i32,
+    pub email_sent: i32,
+    pub email_quota: i32,
+    pub period_end: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Serialize)]
+pub struct BillingReport {
+    pub total_revenue_cents: i64,
+    pub accounts_by_plan: Vec<PlanCount>,
+    pub overage_accounts: Vec<Uuid>,
+}
+
+#[derive(Serialize)]
+pub struct PlanCount {
+    pub plan_slug: String,
+    pub count: i64,
+}
+```
+
+**Step 3: Handlers**
+
+- `GET /admin/billing/accounts` — list with subscription + usage
+- `PATCH /admin/billing/accounts/{id}/plan` — override plan
+- `PATCH /admin/billing/accounts/{id}/usage` — adjust usage
+- `GET /admin/billing/reports` — billing report
+
+**Step 4: Wire routes + commit**
+
+```bash
+git add services/chorus-server/src/
+git commit -m "feat(server): add admin billing endpoints (closes #38)"
+```
+
+---
+
+### Task 10: Admin Webhook Endpoints (#39)
+
+**Files:**
+- Create: `services/chorus-server/src/routes/admin/webhooks.rs`
+- Create: `services/chorus-server/src/db/migrations/006_webhook_deliveries.sql`
+- Modify: `services/chorus-server/src/routes/admin/mod.rs`
+- Modify: `services/chorus-server/src/db/admin.rs`
+
+**Step 1: Create webhook_deliveries table migration**
+
+Currently webhook delivery logs are not persisted (only retried via Redis). We need a table to store delivery history for the admin panel.
+
+```sql
+CREATE TABLE webhook_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    webhook_id UUID NOT NULL REFERENCES webhooks(id),
+    event TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    response_status INTEGER,
+    response_body TEXT,
+    attempt INTEGER NOT NULL DEFAULT 1,
+    success BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_webhook_deliveries_webhook_id ON webhook_deliveries (webhook_id);
+CREATE INDEX idx_webhook_deliveries_created_at ON webhook_deliveries (created_at DESC);
+```
+
+**Step 2: Add webhook admin methods to AdminRepository**
+
+```rust
+    /// List all webhooks across all accounts.
+    async fn list_all_webhooks(&self) -> Result<Vec<AdminWebhook>, DbError>;
+    /// Get webhook delivery log.
+    async fn get_webhook_deliveries(
+        &self,
+        webhook_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<WebhookDelivery>, DbError>;
+    /// Enable/disable a webhook.
+    async fn update_webhook_status(&self, id: Uuid, is_active: bool) -> Result<(), DbError>;
+    /// Disable all webhooks for an account.
+    async fn disable_account_webhooks(&self, account_id: Uuid) -> Result<u64, DbError>;
+```
+
+**Step 3: Test delivery endpoint**
+
+`POST /admin/webhooks/{id}/test` sends a test payload to the webhook URL using the existing `deliver_webhook()` function from `webhook_dispatch.rs`.
+
+**Step 4: Handlers**
+
+- `GET /admin/webhooks` — list all
+- `GET /admin/webhooks/{id}/deliveries` — delivery log
+- `POST /admin/webhooks/{id}/test` — send test event
+- `PATCH /admin/webhooks/{id}` — enable/disable
+
+**Step 5: Update webhook_dispatch.rs**
+
+Modify `deliver_webhook()` to also INSERT into `webhook_deliveries` table for audit trail. This requires passing a `PgPool` or repo reference to the dispatch function.
+
+**Step 6: Wire routes + commit**
+
+```bash
+git add services/chorus-server/src/ services/chorus-server/src/db/migrations/
+git commit -m "feat(server): add admin webhook endpoints + delivery log (closes #39)"
+```
+
+---
+
+### Task 11: Add Integration Tests for Admin Auth
+
+**Files:**
+- Modify: `services/chorus-server/tests/api_test.rs`
+
+**Step 1: Add admin auth tests**
+
+```rust
+#[tokio::test]
+async fn admin_accounts_without_auth_returns_401() {
+    let app = create_test_app().await;
+    let response = app.get("/admin/accounts").send().await;
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn admin_accounts_with_user_key_returns_401() {
+    let app = create_test_app().await;
+    let response = app
+        .get("/admin/accounts")
+        .header("authorization", "Bearer ch_live_test123")
+        .send()
+        .await;
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn admin_accounts_with_admin_key_returns_200() {
+    let app = create_test_app_with_admin_key().await;
+    let response = app
+        .get("/admin/accounts")
+        .header("authorization", "Bearer ch_admin_testkey")
+        .send()
+        .await;
+    assert_eq!(response.status(), 200);
+}
+```
+
+**Step 2: Run tests**
+
+```bash
+cargo test -p chorus-server
+```
+
+**Step 3: Commit**
+
+```bash
+git add services/chorus-server/tests/
+git commit -m "test(server): add admin auth integration tests"
+```
+
+---
+
+### Task 12: Final Verification
+
+**Step 1: Run full CI checks**
+
+```bash
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+cargo fmt --all
+cargo deny check
+```
+
+**Step 2: Commit any formatting fixes**
+
+```bash
+git add -A && git commit -m "style: format admin panel code"
+```
+
+(Skip if no changes.)
+
+---
+
+## Summary
+
+| Task | Issue | Scope |
+|------|-------|-------|
+| 1-4 | Foundation | Admin auth migration, extractor, repo, route structure |
+| 5 | #34 | Account management (CRUD + usage stats) |
+| 6 | #35 | Provider config dashboard + health |
+| 7 | #36 | DLQ management (Redis + DB hybrid) |
+| 8 | #37 | Message inspector (cross-account search) |
+| 9 | #38 | Billing administration |
+| 10 | #39 | Webhook admin + delivery log table |
+| 11-12 | All | Integration tests + final verification |

--- a/docs/plans/2026-04-17-structured-logging.md
+++ b/docs/plans/2026-04-17-structured-logging.md
@@ -1,0 +1,326 @@
+# Structured Logging for Loki Integration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enrich Chorus log output with structured fields (request_id, account_id, message_id, channel, provider) so Strata/Loki can filter and correlate logs effectively.
+
+**Architecture:** Add request ID middleware that generates a UUID per HTTP request and injects it into the tracing span. Enrich worker processing spans with message context fields. All structured fields are automatically included in JSON log output.
+
+**Tech Stack:** Rust, Axum, `tracing`, `tracing-subscriber`, `uuid`
+
+**Closes:** #40
+
+---
+
+### Task 1: Add Request ID Middleware
+
+**Files:**
+- Create: `services/chorus-server/src/middleware/request_id.rs`
+- Modify: `services/chorus-server/src/middleware/mod.rs`
+- Modify: `services/chorus-server/src/app.rs`
+
+**Step 1: Create request ID middleware**
+
+Create `services/chorus-server/src/middleware/request_id.rs`:
+```rust
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use uuid::Uuid;
+
+/// Middleware that generates a unique request ID and wraps the request in a tracing span.
+pub async fn inject(request: axum::extract::Request, next: Next) -> impl IntoResponse {
+    let request_id = request
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned())
+        .unwrap_or_else(|| Uuid::now_v7().to_string());
+
+    let span = tracing::info_span!(
+        "request",
+        request_id = %request_id,
+        method = %request.method(),
+        path = %request.uri().path(),
+    );
+
+    let response = {
+        let _guard = span.enter();
+        next.run(request).await
+    };
+
+    let mut response = response;
+    response.headers_mut().insert(
+        "x-request-id",
+        request_id.parse().expect("valid header value"),
+    );
+    response
+}
+```
+
+**Step 2: Export module**
+
+In `services/chorus-server/src/middleware/mod.rs`, add:
+```rust
+pub mod request_id;
+```
+
+**Step 3: Wire into router**
+
+In `app.rs`, add the request_id middleware layer *before* the metrics middleware (outermost layer runs first):
+```rust
+    .layer(axum_middleware::from_fn(crate::middleware::metrics::track))
+    .layer(axum_middleware::from_fn(crate::middleware::request_id::inject));
+```
+
+Note: layers are applied in reverse order — the last `.layer()` is the outermost. So request_id should be added after metrics to run first.
+
+**Step 4: Run `cargo check -p chorus-server`**
+
+Expected: compiles cleanly.
+
+**Step 5: Run `cargo test -p chorus-server`**
+
+Expected: all tests pass. Verify `x-request-id` header is present in responses.
+
+**Step 6: Commit**
+
+```bash
+git add services/chorus-server/src/middleware/ services/chorus-server/src/app.rs
+git commit -m "feat(server): add request ID middleware for Loki correlation"
+```
+
+---
+
+### Task 2: Enrich Worker Spans with Message Context
+
+**Files:**
+- Modify: `services/chorus-server/src/queue/worker.rs`
+
+**Step 1: Add tracing span to process_next_job**
+
+After the job is deserialized (line where `let job: super::SendJob = ...`), wrap the remainder of the function in a tracing span:
+
+```rust
+    let job: super::SendJob = serde_json::from_str(&payload)?;
+
+    let span = tracing::info_span!(
+        "process_job",
+        message_id = %job.message_id,
+        account_id = %job.account_id,
+        channel = %job.channel,
+        environment = %job.environment,
+        attempt = job.attempt,
+    );
+    let _guard = span.enter();
+```
+
+**Step 2: Add provider field to span on successful send**
+
+After the send result is known, record the provider:
+```rust
+        Ok(result) => {
+            tracing::Span::current().record("provider", &result.provider.as_str());
+            // ... existing code
+        }
+```
+
+Note: for this to work, the span must declare provider as an Empty field:
+```rust
+    let span = tracing::info_span!(
+        "process_job",
+        message_id = %job.message_id,
+        account_id = %job.account_id,
+        channel = %job.channel,
+        environment = %job.environment,
+        attempt = job.attempt,
+        provider = tracing::field::Empty,
+    );
+```
+
+**Step 3: Replace raw tracing calls with structured fields**
+
+The existing `tracing::info!()` and `tracing::error!()` calls in worker.rs should now automatically inherit span context. No changes needed — the span fields propagate to child events.
+
+**Step 4: Run `cargo check -p chorus-server`**
+
+Expected: compiles cleanly.
+
+**Step 5: Commit**
+
+```bash
+git add services/chorus-server/src/queue/worker.rs
+git commit -m "feat(server): enrich worker spans with message context fields"
+```
+
+---
+
+### Task 3: Enrich Worker Startup and Error Spans
+
+**Files:**
+- Modify: `services/chorus-server/src/queue/worker.rs`
+
+**Step 1: Add worker ID to spawn loop span**
+
+In `spawn_workers`, wrap each worker loop in a span:
+```rust
+pub fn spawn_workers(state: Arc<AppState>, config: Arc<Config>, concurrency: usize) {
+    for i in 0..concurrency {
+        let state = Arc::clone(&state);
+        let config = Arc::clone(&config);
+        tokio::spawn(async move {
+            let span = tracing::info_span!("worker", worker_id = i);
+            let _guard = span.enter();
+            tracing::info!("queue worker started");
+            loop {
+                if let Err(e) = process_next_job(&state, &config).await {
+                    tracing::error!(error = %e, "worker error");
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+            }
+        });
+    }
+}
+```
+
+**Step 2: Run `cargo check -p chorus-server`**
+
+**Step 3: Commit**
+
+```bash
+git add services/chorus-server/src/queue/worker.rs
+git commit -m "feat(server): add worker_id span to worker loops"
+```
+
+---
+
+### Task 4: Enrich Webhook Dispatch Spans
+
+**Files:**
+- Modify: `services/chorus-server/src/queue/webhook_dispatch.rs`
+
+**Step 1: Add structured fields to webhook dispatch**
+
+In `dispatch_webhooks`, add span:
+```rust
+pub async fn dispatch_webhooks(
+    state: &Arc<AppState>,
+    account_id: Uuid,
+    event: &str,
+    payload: &WebhookPayload,
+) {
+    let span = tracing::info_span!(
+        "dispatch_webhooks",
+        account_id = %account_id,
+        event = %event,
+        message_id = %payload.message_id,
+    );
+    let _guard = span.enter();
+    // ... existing code
+}
+```
+
+In `deliver_webhook`, add span:
+```rust
+async fn deliver_webhook(url: &str, secret: &str, event: &str, body: &str) -> bool {
+    let span = tracing::info_span!("deliver_webhook", url = %url, event = %event);
+    let _guard = span.enter();
+    // ... existing code
+}
+```
+
+**Step 2: Run `cargo check -p chorus-server`**
+
+**Step 3: Commit**
+
+```bash
+git add services/chorus-server/src/queue/webhook_dispatch.rs
+git commit -m "feat(server): add structured spans to webhook dispatch"
+```
+
+---
+
+### Task 5: Add Structured Fields to Delayed Queue Poller
+
+**Files:**
+- Modify: `services/chorus-server/src/queue/delayed.rs`
+
+**Step 1: Add span to poll_delayed_jobs**
+
+```rust
+async fn poll_delayed_jobs(redis: &redis::Client) -> anyhow::Result<()> {
+    let mut conn = redis.get_multiplexed_tokio_connection().await?;
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+
+    // ... existing ZRANGEBYSCORE code ...
+
+    for payload in jobs {
+        let job: super::SendJob = match serde_json::from_str(&payload) {
+            Ok(j) => j,
+            Err(_) => continue,
+        };
+
+        let span = tracing::info_span!(
+            "requeue_delayed",
+            message_id = %job.message_id,
+            account_id = %job.account_id,
+            attempt = job.attempt,
+        );
+        let _guard = span.enter();
+
+        // ... existing ZREM + LPUSH code ...
+        tracing::debug!("moved delayed job back to main queue");
+    }
+
+    Ok(())
+}
+```
+
+Note: This changes the loop to parse the job JSON before ZREM, which is fine — we already have the payload string.
+
+**Step 2: Run `cargo check -p chorus-server`**
+
+**Step 3: Commit**
+
+```bash
+git add services/chorus-server/src/queue/delayed.rs
+git commit -m "feat(server): add structured spans to delayed queue poller"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Step 1: Run full CI checks**
+
+```bash
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+cargo fmt --all
+cargo deny check
+```
+
+**Step 2: Verify JSON log output**
+
+Manually test with `CHORUS_LOG_FORMAT=json cargo run` (or check that the structured fields appear in log output). Expected fields in JSON logs:
+- HTTP requests: `request_id`, `method`, `path`
+- Worker processing: `message_id`, `account_id`, `channel`, `provider`, `attempt`, `worker_id`
+- Webhook dispatch: `account_id`, `event`, `message_id`, `url`
+
+**Step 3: Commit any fixes**
+
+```bash
+git add -A && git commit -m "style: format structured logging code"
+```
+
+---
+
+## Summary of Changes
+
+| Task | Component | Structured Fields Added |
+|------|-----------|----------------------|
+| 1 | Request ID middleware | request_id, method, path + X-Request-Id header |
+| 2 | Worker job processing | message_id, account_id, channel, environment, attempt, provider |
+| 3 | Worker startup | worker_id |
+| 4 | Webhook dispatch | account_id, event, message_id, url |
+| 5 | Delayed queue poller | message_id, account_id, attempt |
+| 6 | Verification | Full CI + JSON log verification |

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -11,8 +11,8 @@ use crate::db::postgres::PgRepository;
 use crate::db::provider_config::PgProviderConfigRepository;
 use crate::db::webhook::PgWebhookRepository;
 use crate::db::{
-    AccountRepository, AdminKeyRepository, ApiKeyRepository, MessageRepository,
-    ProviderConfigRepository, WebhookRepository,
+    AccountRepository, AdminKeyRepository, AdminRepository, ApiKeyRepository, MessageRepository,
+    PgAdminRepository, ProviderConfigRepository, WebhookRepository,
 };
 use crate::routes;
 
@@ -40,6 +40,8 @@ pub struct AppState {
     billing_repo: Arc<dyn BillingRepository>,
     /// Admin key repository.
     admin_key_repo: Arc<dyn AdminKeyRepository>,
+    /// Admin repository for cross-account queries.
+    admin_repo: Arc<dyn AdminRepository>,
 }
 
 impl AppState {
@@ -49,6 +51,7 @@ impl AppState {
         let provider_config_repo = Arc::new(PgProviderConfigRepository::new(db.clone()));
         let webhook_repo = Arc::new(PgWebhookRepository::new(db.clone()));
         let billing_repo = Arc::new(PgBillingRepository::new(db.clone()));
+        let admin_repo = Arc::new(PgAdminRepository::new(db.clone()));
         Self {
             db: Some(db),
             redis,
@@ -61,6 +64,7 @@ impl AppState {
             provider_config_repo,
             webhook_repo,
             billing_repo,
+            admin_repo,
         }
     }
 
@@ -86,6 +90,7 @@ impl AppState {
             webhook_repo,
             billing_repo: Arc::new(crate::db::billing::NullBillingRepository),
             admin_key_repo: Arc::new(NullAdminKeyRepository),
+            admin_repo: Arc::new(NullAdminRepository),
         }
     }
 
@@ -122,6 +127,11 @@ impl AppState {
     /// Access the admin key repository.
     pub fn admin_key_repo(&self) -> Arc<dyn AdminKeyRepository> {
         Arc::clone(&self.admin_key_repo)
+    }
+
+    /// Access the admin repository.
+    pub fn admin_repo(&self) -> Arc<dyn AdminRepository> {
+        Arc::clone(&self.admin_repo)
     }
 
     /// Access the shared HTTP client.
@@ -189,6 +199,7 @@ pub fn create_router_with_metrics(
         .route("/v1/billing/usage", get(routes::billing::get_usage))
         .route("/internal/bounces", post(routes::internal::handle_bounce))
         .route("/internal/dns-check", get(routes::internal::dns_check))
+        .nest("/admin", routes::admin::router())
         .with_state(state)
         .layer(axum_middleware::from_fn(crate::middleware::metrics::track));
 
@@ -206,9 +217,75 @@ pub fn create_router_with_metrics(
 /// No-op admin key repository for tests.
 struct NullAdminKeyRepository;
 
+/// No-op admin repository for tests.
+struct NullAdminRepository;
+
 #[async_trait::async_trait]
 impl AdminKeyRepository for NullAdminKeyRepository {
-    async fn find_by_hash(&self, _hash: &str) -> Result<Option<crate::db::AdminKey>, crate::db::DbError> {
+    async fn find_by_hash(
+        &self,
+        _hash: &str,
+    ) -> Result<Option<crate::db::AdminKey>, crate::db::DbError> {
         Ok(None)
+    }
+}
+
+#[async_trait::async_trait]
+impl AdminRepository for NullAdminRepository {
+    async fn list_accounts(
+        &self,
+    ) -> Result<Vec<crate::routes::admin::accounts::AccountListItem>, crate::db::DbError> {
+        Ok(vec![])
+    }
+    async fn get_account_detail(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<Option<crate::routes::admin::accounts::AccountDetail>, crate::db::DbError> {
+        Ok(None)
+    }
+    async fn create_account(
+        &self,
+        _name: &str,
+        _email: &str,
+    ) -> Result<crate::routes::admin::accounts::AccountListItem, crate::db::DbError> {
+        Err(crate::db::DbError::Internal(anyhow::anyhow!(
+            "not implemented"
+        )))
+    }
+    async fn update_account(
+        &self,
+        _id: uuid::Uuid,
+        _is_active: Option<bool>,
+        _name: Option<&str>,
+    ) -> Result<(), crate::db::DbError> {
+        Ok(())
+    }
+    async fn deactivate_account(&self, _id: uuid::Uuid) -> Result<(), crate::db::DbError> {
+        Ok(())
+    }
+    async fn list_all_provider_configs(
+        &self,
+    ) -> Result<Vec<crate::routes::admin::providers::AdminProviderConfig>, crate::db::DbError> {
+        Ok(vec![])
+    }
+    async fn get_provider_health(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<Option<crate::routes::admin::providers::ProviderHealth>, crate::db::DbError> {
+        Ok(None)
+    }
+    async fn update_provider_config(
+        &self,
+        _id: uuid::Uuid,
+        _priority: Option<i32>,
+        _is_active: Option<bool>,
+    ) -> Result<(), crate::db::DbError> {
+        Ok(())
+    }
+    async fn disable_provider_by_name(
+        &self,
+        _provider: &str,
+    ) -> Result<u64, crate::db::DbError> {
+        Ok(0)
     }
 }

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -11,8 +11,8 @@ use crate::db::postgres::PgRepository;
 use crate::db::provider_config::PgProviderConfigRepository;
 use crate::db::webhook::PgWebhookRepository;
 use crate::db::{
-    AccountRepository, ApiKeyRepository, MessageRepository, ProviderConfigRepository,
-    WebhookRepository,
+    AccountRepository, AdminKeyRepository, ApiKeyRepository, MessageRepository,
+    ProviderConfigRepository, WebhookRepository,
 };
 use crate::routes;
 
@@ -38,6 +38,8 @@ pub struct AppState {
     webhook_repo: Arc<dyn WebhookRepository>,
     /// Billing repository.
     billing_repo: Arc<dyn BillingRepository>,
+    /// Admin key repository.
+    admin_key_repo: Arc<dyn AdminKeyRepository>,
 }
 
 impl AppState {
@@ -54,7 +56,8 @@ impl AppState {
             config,
             account_repo: repo.clone(),
             message_repo: repo.clone(),
-            api_key_repo: repo,
+            api_key_repo: repo.clone(),
+            admin_key_repo: repo,
             provider_config_repo,
             webhook_repo,
             billing_repo,
@@ -82,6 +85,7 @@ impl AppState {
             provider_config_repo,
             webhook_repo,
             billing_repo: Arc::new(crate::db::billing::NullBillingRepository),
+            admin_key_repo: Arc::new(NullAdminKeyRepository),
         }
     }
 
@@ -113,6 +117,11 @@ impl AppState {
     /// Access the billing repository.
     pub fn billing_repo(&self) -> Arc<dyn BillingRepository> {
         Arc::clone(&self.billing_repo)
+    }
+
+    /// Access the admin key repository.
+    pub fn admin_key_repo(&self) -> Arc<dyn AdminKeyRepository> {
+        Arc::clone(&self.admin_key_repo)
     }
 
     /// Access the shared HTTP client.
@@ -192,4 +201,14 @@ pub fn create_router_with_metrics(
     }
 
     router
+}
+
+/// No-op admin key repository for tests.
+struct NullAdminKeyRepository;
+
+#[async_trait::async_trait]
+impl AdminKeyRepository for NullAdminKeyRepository {
+    async fn find_by_hash(&self, _hash: &str) -> Result<Option<crate::db::AdminKey>, crate::db::DbError> {
+        Ok(None)
+    }
 }

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -282,10 +282,7 @@ impl AdminRepository for NullAdminRepository {
     ) -> Result<(), crate::db::DbError> {
         Ok(())
     }
-    async fn disable_provider_by_name(
-        &self,
-        _provider: &str,
-    ) -> Result<u64, crate::db::DbError> {
+    async fn disable_provider_by_name(&self, _provider: &str) -> Result<u64, crate::db::DbError> {
         Ok(0)
     }
     async fn get_message_by_id(
@@ -328,5 +325,37 @@ impl AdminRepository for NullAdminRepository {
             accounts_by_plan: vec![],
             overage_accounts: vec![],
         })
+    }
+    async fn list_all_webhooks(
+        &self,
+    ) -> Result<Vec<crate::routes::admin::webhooks::AdminWebhook>, crate::db::DbError> {
+        Ok(vec![])
+    }
+    async fn get_webhook_by_id(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<Option<crate::db::Webhook>, crate::db::DbError> {
+        Ok(None)
+    }
+    async fn get_webhook_deliveries(
+        &self,
+        _webhook_id: uuid::Uuid,
+        _limit: i64,
+        _offset: i64,
+    ) -> Result<Vec<crate::routes::admin::webhooks::WebhookDelivery>, crate::db::DbError> {
+        Ok(vec![])
+    }
+    async fn update_webhook_status(
+        &self,
+        _id: uuid::Uuid,
+        _is_active: bool,
+    ) -> Result<(), crate::db::DbError> {
+        Ok(())
+    }
+    async fn disable_account_webhooks(
+        &self,
+        _account_id: uuid::Uuid,
+    ) -> Result<u64, crate::db::DbError> {
+        Ok(0)
     }
 }

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -288,4 +288,45 @@ impl AdminRepository for NullAdminRepository {
     ) -> Result<u64, crate::db::DbError> {
         Ok(0)
     }
+    async fn get_message_by_id(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<Option<crate::db::Message>, crate::db::DbError> {
+        Ok(None)
+    }
+    async fn search_messages(
+        &self,
+        _filters: &crate::routes::admin::messages::MessageSearchFilters,
+    ) -> Result<Vec<crate::db::Message>, crate::db::DbError> {
+        Ok(vec![])
+    }
+    async fn list_billing_accounts(
+        &self,
+    ) -> Result<Vec<crate::routes::admin::billing::BillingAccountSummary>, crate::db::DbError> {
+        Ok(vec![])
+    }
+    async fn override_plan(
+        &self,
+        _account_id: uuid::Uuid,
+        _plan_slug: &str,
+    ) -> Result<(), crate::db::DbError> {
+        Ok(())
+    }
+    async fn adjust_usage(
+        &self,
+        _account_id: uuid::Uuid,
+        _sms_delta: Option<i32>,
+        _email_delta: Option<i32>,
+    ) -> Result<(), crate::db::DbError> {
+        Ok(())
+    }
+    async fn billing_report(
+        &self,
+    ) -> Result<crate::routes::admin::billing::BillingReport, crate::db::DbError> {
+        Ok(crate::routes::admin::billing::BillingReport {
+            total_revenue_cents: 0,
+            accounts_by_plan: vec![],
+            overage_accounts: vec![],
+        })
+    }
 }

--- a/services/chorus-server/src/auth/admin.rs
+++ b/services/chorus-server/src/auth/admin.rs
@@ -1,0 +1,55 @@
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+
+/// Authenticated admin context extracted from an admin API key.
+#[derive(Debug, Clone)]
+pub struct AdminContext {
+    /// The admin key ID used to authenticate.
+    pub key_id: Uuid,
+}
+
+impl FromRequestParts<Arc<AppState>> for AdminContext {
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        let header = parts
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .ok_or((StatusCode::UNAUTHORIZED, "missing authorization header"))?;
+
+        let key = header
+            .strip_prefix("Bearer ")
+            .ok_or((StatusCode::UNAUTHORIZED, "invalid authorization format"))?;
+
+        if !key.starts_with("ch_admin_") {
+            return Err((StatusCode::UNAUTHORIZED, "invalid admin key format"));
+        }
+
+        let hash = hex::encode(Sha256::digest(key.as_bytes()));
+
+        let admin_key = state
+            .admin_key_repo()
+            .find_by_hash(&hash)
+            .await
+            .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "database error"))?
+            .ok_or((StatusCode::UNAUTHORIZED, "invalid admin key"))?;
+
+        if admin_key.is_revoked {
+            return Err((StatusCode::UNAUTHORIZED, "admin key is revoked"));
+        }
+
+        Ok(AdminContext {
+            key_id: admin_key.id,
+        })
+    }
+}

--- a/services/chorus-server/src/auth/mod.rs
+++ b/services/chorus-server/src/auth/mod.rs
@@ -1,1 +1,2 @@
+pub mod admin;
 pub mod api_key;

--- a/services/chorus-server/src/db/admin.rs
+++ b/services/chorus-server/src/db/admin.rs
@@ -1,0 +1,203 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::DbError;
+use crate::routes::admin::accounts::{AccountDetail, AccountListItem};
+use crate::routes::admin::providers::{AdminProviderConfig, ProviderHealth};
+
+/// Repository for admin-only cross-account queries.
+#[async_trait]
+pub trait AdminRepository: Send + Sync {
+    /// List all accounts.
+    async fn list_accounts(&self) -> Result<Vec<AccountListItem>, DbError>;
+    /// Get account detail with usage stats.
+    async fn get_account_detail(&self, id: Uuid) -> Result<Option<AccountDetail>, DbError>;
+    /// Create a new account.
+    async fn create_account(&self, name: &str, email: &str) -> Result<AccountListItem, DbError>;
+    /// Update account fields.
+    async fn update_account(
+        &self,
+        id: Uuid,
+        is_active: Option<bool>,
+        name: Option<&str>,
+    ) -> Result<(), DbError>;
+    /// Deactivate (soft-delete) an account.
+    async fn deactivate_account(&self, id: Uuid) -> Result<(), DbError>;
+
+    // --- Provider Config (#35) ---
+
+    /// List all provider configs across accounts.
+    async fn list_all_provider_configs(&self) -> Result<Vec<AdminProviderConfig>, DbError>;
+    /// Get provider health summary (error rate from recent delivery events).
+    async fn get_provider_health(&self, id: Uuid) -> Result<Option<ProviderHealth>, DbError>;
+    /// Update provider config (priority, is_active).
+    async fn update_provider_config(
+        &self,
+        id: Uuid,
+        priority: Option<i32>,
+        is_active: Option<bool>,
+    ) -> Result<(), DbError>;
+    /// Disable a provider across all accounts (outage scenario).
+    async fn disable_provider_by_name(&self, provider: &str) -> Result<u64, DbError>;
+}
+
+/// PostgreSQL implementation of admin repository.
+pub struct PgAdminRepository {
+    pool: PgPool,
+}
+
+impl PgAdminRepository {
+    /// Create a new admin repository.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl AdminRepository for PgAdminRepository {
+    async fn list_accounts(&self) -> Result<Vec<AccountListItem>, DbError> {
+        let rows = sqlx::query_as::<_, AccountListItem>(
+            "SELECT id, name, owner_email, is_active, created_at
+             FROM accounts ORDER BY created_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(rows)
+    }
+
+    async fn get_account_detail(&self, id: Uuid) -> Result<Option<AccountDetail>, DbError> {
+        let row = sqlx::query_as::<_, AccountDetail>(
+            "SELECT a.id, a.name, a.owner_email, a.is_active, a.created_at, a.updated_at,
+                    (SELECT COUNT(*) FROM api_keys WHERE account_id = a.id) AS key_count,
+                    (SELECT COUNT(*) FROM messages WHERE account_id = a.id) AS message_count
+             FROM accounts a WHERE a.id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(row)
+    }
+
+    async fn create_account(&self, name: &str, email: &str) -> Result<AccountListItem, DbError> {
+        let row = sqlx::query_as::<_, AccountListItem>(
+            "INSERT INTO accounts (name, owner_email) VALUES ($1, $2)
+             RETURNING id, name, owner_email, is_active, created_at",
+        )
+        .bind(name)
+        .bind(email)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(row)
+    }
+
+    async fn update_account(
+        &self,
+        id: Uuid,
+        is_active: Option<bool>,
+        name: Option<&str>,
+    ) -> Result<(), DbError> {
+        sqlx::query(
+            "UPDATE accounts SET
+                is_active = COALESCE($1, is_active),
+                name = COALESCE($2, name),
+                updated_at = now()
+             WHERE id = $3",
+        )
+        .bind(is_active)
+        .bind(name)
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(())
+    }
+
+    async fn deactivate_account(&self, id: Uuid) -> Result<(), DbError> {
+        sqlx::query("UPDATE accounts SET is_active = false, updated_at = now() WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(())
+    }
+
+    async fn list_all_provider_configs(&self) -> Result<Vec<AdminProviderConfig>, DbError> {
+        let rows = sqlx::query_as::<_, AdminProviderConfig>(
+            "SELECT id, account_id, channel, provider, priority, is_active, created_at
+             FROM provider_configs ORDER BY account_id, priority",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(rows)
+    }
+
+    async fn get_provider_health(&self, id: Uuid) -> Result<Option<ProviderHealth>, DbError> {
+        let row = sqlx::query_as::<_, ProviderHealth>(
+            "SELECT pc.id, pc.provider,
+                    COUNT(CASE WHEN m.status = 'delivered' THEN 1 END) AS total_sent,
+                    COUNT(CASE WHEN m.status = 'failed' THEN 1 END) AS total_errors,
+                    CASE
+                        WHEN COUNT(*) FILTER (WHERE m.status IN ('delivered', 'failed')) = 0 THEN 0.0
+                        ELSE COUNT(CASE WHEN m.status = 'failed' THEN 1 END)::float
+                             / COUNT(*) FILTER (WHERE m.status IN ('delivered', 'failed'))
+                    END AS error_rate,
+                    MAX(CASE WHEN m.status = 'delivered' THEN m.delivered_at END) AS last_success,
+                    MAX(CASE WHEN de.status = 'failed_attempt' THEN de.created_at END) AS last_error
+             FROM provider_configs pc
+             LEFT JOIN messages m ON m.provider = pc.provider AND m.account_id = pc.account_id
+             LEFT JOIN delivery_events de ON de.message_id = m.id
+             WHERE pc.id = $1
+             GROUP BY pc.id, pc.provider",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(row)
+    }
+
+    async fn update_provider_config(
+        &self,
+        id: Uuid,
+        priority: Option<i32>,
+        is_active: Option<bool>,
+    ) -> Result<(), DbError> {
+        sqlx::query(
+            "UPDATE provider_configs SET
+                priority = COALESCE($1, priority),
+                is_active = COALESCE($2, is_active)
+             WHERE id = $3",
+        )
+        .bind(priority)
+        .bind(is_active)
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(())
+    }
+
+    async fn disable_provider_by_name(&self, provider: &str) -> Result<u64, DbError> {
+        let result =
+            sqlx::query("UPDATE provider_configs SET is_active = false WHERE provider = $1")
+                .bind(provider)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(result.rows_affected())
+    }
+}

--- a/services/chorus-server/src/db/admin.rs
+++ b/services/chorus-server/src/db/admin.rs
@@ -2,8 +2,10 @@ use async_trait::async_trait;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use super::DbError;
+use super::{DbError, Message};
 use crate::routes::admin::accounts::{AccountDetail, AccountListItem};
+use crate::routes::admin::billing::{BillingAccountSummary, BillingReport, PlanCount};
+use crate::routes::admin::messages::MessageSearchFilters;
 use crate::routes::admin::providers::{AdminProviderConfig, ProviderHealth};
 
 /// Repository for admin-only cross-account queries.
@@ -40,6 +42,29 @@ pub trait AdminRepository: Send + Sync {
     ) -> Result<(), DbError>;
     /// Disable a provider across all accounts (outage scenario).
     async fn disable_provider_by_name(&self, provider: &str) -> Result<u64, DbError>;
+
+    // --- DLQ + Message Inspector (#36, #37) ---
+
+    /// Get a message by ID without account scoping (admin-only).
+    async fn get_message_by_id(&self, id: Uuid) -> Result<Option<Message>, DbError>;
+    /// Search messages across all accounts with filters.
+    async fn search_messages(&self, filters: &MessageSearchFilters) -> Result<Vec<Message>, DbError>;
+
+    // --- Billing (#38) ---
+
+    /// List all accounts with billing status.
+    async fn list_billing_accounts(&self) -> Result<Vec<BillingAccountSummary>, DbError>;
+    /// Override an account's subscription plan.
+    async fn override_plan(&self, account_id: Uuid, plan_slug: &str) -> Result<(), DbError>;
+    /// Adjust usage counters.
+    async fn adjust_usage(
+        &self,
+        account_id: Uuid,
+        sms_delta: Option<i32>,
+        email_delta: Option<i32>,
+    ) -> Result<(), DbError>;
+    /// Generate billing report.
+    async fn billing_report(&self) -> Result<BillingReport, DbError>;
 }
 
 /// PostgreSQL implementation of admin repository.
@@ -199,5 +224,220 @@ impl AdminRepository for PgAdminRepository {
                 .map_err(|e| DbError::Internal(e.into()))?;
 
         Ok(result.rows_affected())
+    }
+
+    async fn get_message_by_id(&self, id: Uuid) -> Result<Option<Message>, DbError> {
+        let msg = sqlx::query_as::<_, Message>("SELECT * FROM messages WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(msg)
+    }
+
+    async fn search_messages(
+        &self,
+        filters: &MessageSearchFilters,
+    ) -> Result<Vec<Message>, DbError> {
+        // Build dynamic query with conditional WHERE clauses
+        let mut conditions = Vec::new();
+        let mut param_idx = 1u32;
+
+        if filters.account_id.is_some() {
+            conditions.push(format!("account_id = ${param_idx}"));
+            param_idx += 1;
+        }
+        if filters.channel.is_some() {
+            conditions.push(format!("channel = ${param_idx}"));
+            param_idx += 1;
+        }
+        if filters.status.is_some() {
+            conditions.push(format!("status = ${param_idx}"));
+            param_idx += 1;
+        }
+        if filters.provider.is_some() {
+            conditions.push(format!("provider = ${param_idx}"));
+            param_idx += 1;
+        }
+        if filters.date_from.is_some() {
+            conditions.push(format!("created_at >= ${param_idx}"));
+            param_idx += 1;
+        }
+        if filters.date_to.is_some() {
+            conditions.push(format!("created_at <= ${param_idx}"));
+            param_idx += 1;
+        }
+        if filters.recipient.is_some() {
+            conditions.push(format!("recipient ILIKE ${param_idx}"));
+            param_idx += 1;
+        }
+        if filters.min_cost.is_some() {
+            conditions.push(format!("cost_microdollars >= ${param_idx}"));
+            param_idx += 1;
+        }
+        if filters.max_cost.is_some() {
+            conditions.push(format!("cost_microdollars <= ${param_idx}"));
+            param_idx += 1;
+        }
+
+        let where_clause = if conditions.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", conditions.join(" AND "))
+        };
+
+        let limit_param = param_idx;
+        param_idx += 1;
+        let offset_param = param_idx;
+
+        let sql = format!(
+            "SELECT * FROM messages {where_clause} ORDER BY created_at DESC LIMIT ${limit_param} OFFSET ${offset_param}"
+        );
+
+        let mut query = sqlx::query_as::<_, Message>(&sql);
+
+        // Bind parameters in the same order
+        if let Some(ref v) = filters.account_id {
+            query = query.bind(v);
+        }
+        if let Some(ref v) = filters.channel {
+            query = query.bind(v);
+        }
+        if let Some(ref v) = filters.status {
+            query = query.bind(v);
+        }
+        if let Some(ref v) = filters.provider {
+            query = query.bind(v);
+        }
+        if let Some(ref v) = filters.date_from {
+            query = query.bind(v);
+        }
+        if let Some(ref v) = filters.date_to {
+            query = query.bind(v);
+        }
+        if let Some(ref v) = filters.recipient {
+            query = query.bind(format!("%{v}%"));
+        }
+        if let Some(ref v) = filters.min_cost {
+            query = query.bind(v);
+        }
+        if let Some(ref v) = filters.max_cost {
+            query = query.bind(v);
+        }
+
+        let limit = filters.limit.unwrap_or(50);
+        let offset = filters.offset.unwrap_or(0);
+        query = query.bind(limit).bind(offset);
+
+        let messages = query
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(messages)
+    }
+
+    async fn list_billing_accounts(&self) -> Result<Vec<BillingAccountSummary>, DbError> {
+        let rows = sqlx::query_as::<_, BillingAccountSummary>(
+            "SELECT a.id AS account_id, a.name AS account_name,
+                    bp.slug AS plan_slug, s.status,
+                    COALESCE(u.sms_sent, 0) AS sms_sent, bp.sms_quota,
+                    COALESCE(u.email_sent, 0) AS email_sent, bp.email_quota,
+                    s.period_end
+             FROM accounts a
+             JOIN subscriptions s ON s.account_id = a.id
+             JOIN billing_plans bp ON bp.id = s.plan_id
+             LEFT JOIN usage u ON u.account_id = a.id
+                 AND u.period_start = s.period_start
+             ORDER BY a.name",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(rows)
+    }
+
+    async fn override_plan(&self, account_id: Uuid, plan_slug: &str) -> Result<(), DbError> {
+        sqlx::query(
+            "UPDATE subscriptions SET plan_id = (SELECT id FROM billing_plans WHERE slug = $1)
+             WHERE account_id = $2",
+        )
+        .bind(plan_slug)
+        .bind(account_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(())
+    }
+
+    async fn adjust_usage(
+        &self,
+        account_id: Uuid,
+        sms_delta: Option<i32>,
+        email_delta: Option<i32>,
+    ) -> Result<(), DbError> {
+        sqlx::query(
+            "UPDATE usage SET
+                sms_sent = sms_sent + COALESCE($1, 0),
+                email_sent = email_sent + COALESCE($2, 0)
+             WHERE account_id = $3
+             AND period_start <= now() AND period_end > now()",
+        )
+        .bind(sms_delta)
+        .bind(email_delta)
+        .bind(account_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(())
+    }
+
+    async fn billing_report(&self) -> Result<BillingReport, DbError> {
+        // Total revenue from active subscriptions
+        let revenue: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(bp.price_cents), 0)
+             FROM subscriptions s
+             JOIN billing_plans bp ON bp.id = s.plan_id
+             WHERE s.status = 'active'",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        // Accounts by plan
+        let accounts_by_plan = sqlx::query_as::<_, PlanCount>(
+            "SELECT bp.slug AS plan_slug, COUNT(*) AS count
+             FROM subscriptions s
+             JOIN billing_plans bp ON bp.id = s.plan_id
+             GROUP BY bp.slug ORDER BY count DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        // Accounts exceeding quotas
+        let overage_rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT a.id
+             FROM accounts a
+             JOIN subscriptions s ON s.account_id = a.id
+             JOIN billing_plans bp ON bp.id = s.plan_id
+             LEFT JOIN usage u ON u.account_id = a.id
+                 AND u.period_start = s.period_start
+             WHERE (bp.sms_quota > 0 AND COALESCE(u.sms_sent, 0) > bp.sms_quota)
+                OR (bp.email_quota > 0 AND COALESCE(u.email_sent, 0) > bp.email_quota)",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(BillingReport {
+            total_revenue_cents: revenue.0,
+            accounts_by_plan,
+            overage_accounts: overage_rows.into_iter().map(|r| r.0).collect(),
+        })
     }
 }

--- a/services/chorus-server/src/db/admin.rs
+++ b/services/chorus-server/src/db/admin.rs
@@ -2,11 +2,12 @@ use async_trait::async_trait;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use super::{DbError, Message};
+use super::{DbError, Message, Webhook};
 use crate::routes::admin::accounts::{AccountDetail, AccountListItem};
 use crate::routes::admin::billing::{BillingAccountSummary, BillingReport, PlanCount};
 use crate::routes::admin::messages::MessageSearchFilters;
 use crate::routes::admin::providers::{AdminProviderConfig, ProviderHealth};
+use crate::routes::admin::webhooks::{AdminWebhook, WebhookDelivery};
 
 /// Repository for admin-only cross-account queries.
 #[async_trait]
@@ -48,7 +49,10 @@ pub trait AdminRepository: Send + Sync {
     /// Get a message by ID without account scoping (admin-only).
     async fn get_message_by_id(&self, id: Uuid) -> Result<Option<Message>, DbError>;
     /// Search messages across all accounts with filters.
-    async fn search_messages(&self, filters: &MessageSearchFilters) -> Result<Vec<Message>, DbError>;
+    async fn search_messages(
+        &self,
+        filters: &MessageSearchFilters,
+    ) -> Result<Vec<Message>, DbError>;
 
     // --- Billing (#38) ---
 
@@ -65,6 +69,24 @@ pub trait AdminRepository: Send + Sync {
     ) -> Result<(), DbError>;
     /// Generate billing report.
     async fn billing_report(&self) -> Result<BillingReport, DbError>;
+
+    // --- Webhook (#39) ---
+
+    /// List all webhooks across all accounts.
+    async fn list_all_webhooks(&self) -> Result<Vec<AdminWebhook>, DbError>;
+    /// Get a webhook by ID (admin, no account scoping).
+    async fn get_webhook_by_id(&self, id: Uuid) -> Result<Option<Webhook>, DbError>;
+    /// Get webhook delivery log.
+    async fn get_webhook_deliveries(
+        &self,
+        webhook_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<WebhookDelivery>, DbError>;
+    /// Enable/disable a webhook.
+    async fn update_webhook_status(&self, id: Uuid, is_active: bool) -> Result<(), DbError>;
+    /// Disable all webhooks for an account.
+    async fn disable_account_webhooks(&self, account_id: Uuid) -> Result<u64, DbError>;
 }
 
 /// PostgreSQL implementation of admin repository.
@@ -439,5 +461,73 @@ impl AdminRepository for PgAdminRepository {
             accounts_by_plan,
             overage_accounts: overage_rows.into_iter().map(|r| r.0).collect(),
         })
+    }
+
+    async fn list_all_webhooks(&self) -> Result<Vec<AdminWebhook>, DbError> {
+        let rows = sqlx::query_as::<_, AdminWebhook>(
+            "SELECT id, account_id, url, events, is_active, created_at
+             FROM webhooks ORDER BY account_id, created_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(rows)
+    }
+
+    async fn get_webhook_by_id(&self, id: Uuid) -> Result<Option<Webhook>, DbError> {
+        let webhook = sqlx::query_as::<_, Webhook>(
+            "SELECT id, account_id, url, secret, events, is_active, created_at
+             FROM webhooks WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(webhook)
+    }
+
+    async fn get_webhook_deliveries(
+        &self,
+        webhook_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<WebhookDelivery>, DbError> {
+        let rows = sqlx::query_as::<_, WebhookDelivery>(
+            "SELECT id, webhook_id, event, payload, response_status, response_body,
+                    attempt, success, created_at
+             FROM webhook_deliveries WHERE webhook_id = $1
+             ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+        )
+        .bind(webhook_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(rows)
+    }
+
+    async fn update_webhook_status(&self, id: Uuid, is_active: bool) -> Result<(), DbError> {
+        sqlx::query("UPDATE webhooks SET is_active = $1 WHERE id = $2")
+            .bind(is_active)
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(())
+    }
+
+    async fn disable_account_webhooks(&self, account_id: Uuid) -> Result<u64, DbError> {
+        let result = sqlx::query("UPDATE webhooks SET is_active = false WHERE account_id = $1")
+            .bind(account_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(result.rows_affected())
     }
 }

--- a/services/chorus-server/src/db/migrations/005_create_admin_keys.sql
+++ b/services/chorus-server/src/db/migrations/005_create_admin_keys.sql
@@ -1,0 +1,10 @@
+CREATE TABLE admin_keys (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    key_hash TEXT NOT NULL UNIQUE,
+    key_prefix TEXT NOT NULL,
+    is_revoked BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_admin_keys_key_hash ON admin_keys (key_hash);

--- a/services/chorus-server/src/db/migrations/006_webhook_deliveries.sql
+++ b/services/chorus-server/src/db/migrations/006_webhook_deliveries.sql
@@ -1,0 +1,14 @@
+CREATE TABLE webhook_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    webhook_id UUID NOT NULL REFERENCES webhooks(id),
+    event TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    response_status INTEGER,
+    response_body TEXT,
+    attempt INTEGER NOT NULL DEFAULT 1,
+    success BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_webhook_deliveries_webhook_id ON webhook_deliveries (webhook_id);
+CREATE INDEX idx_webhook_deliveries_created_at ON webhook_deliveries (created_at DESC);

--- a/services/chorus-server/src/db/mod.rs
+++ b/services/chorus-server/src/db/mod.rs
@@ -1,7 +1,10 @@
+pub mod admin;
 pub mod billing;
 pub mod postgres;
 pub mod provider_config;
 pub mod webhook;
+
+pub use admin::{AdminRepository, PgAdminRepository};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};

--- a/services/chorus-server/src/db/mod.rs
+++ b/services/chorus-server/src/db/mod.rs
@@ -224,6 +224,23 @@ pub trait WebhookRepository: Send + Sync {
     async fn delete(&self, id: Uuid, account_id: Uuid) -> Result<(), DbError>;
 }
 
+/// An admin API key for dashboard access.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AdminKey {
+    pub id: Uuid,
+    pub name: String,
+    pub key_prefix: String,
+    pub is_revoked: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Repository for admin key operations.
+#[async_trait]
+pub trait AdminKeyRepository: Send + Sync {
+    /// Find an admin key by its SHA-256 hash.
+    async fn find_by_hash(&self, hash: &str) -> Result<Option<AdminKey>, DbError>;
+}
+
 /// API key management operations.
 #[async_trait]
 pub trait ApiKeyRepository: Send + Sync {

--- a/services/chorus-server/src/db/postgres.rs
+++ b/services/chorus-server/src/db/postgres.rs
@@ -15,8 +15,8 @@ macro_rules! record_db_duration {
 }
 
 use super::{
-    Account, AccountRepository, ApiKey, ApiKeyRepository, DbError, DeliveryEvent, Message,
-    MessageRepository, NewMessage, Pagination,
+    Account, AccountRepository, AdminKey, AdminKeyRepository, ApiKey, ApiKeyRepository, DbError,
+    DeliveryEvent, Message, MessageRepository, NewMessage, Pagination,
 };
 
 /// PostgreSQL-backed repository implementation using sqlx.
@@ -252,5 +252,21 @@ impl ApiKeyRepository for PgRepository {
         }
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl AdminKeyRepository for PgRepository {
+    async fn find_by_hash(&self, hash: &str) -> Result<Option<AdminKey>, DbError> {
+        let key = sqlx::query_as::<_, AdminKey>(
+            "SELECT id, name, key_prefix, is_revoked, created_at
+             FROM admin_keys WHERE key_hash = $1",
+        )
+        .bind(hash)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DbError::Internal(e.into()))?;
+
+        Ok(key)
     }
 }

--- a/services/chorus-server/src/routes/admin/accounts.rs
+++ b/services/chorus-server/src/routes/admin/accounts.rs
@@ -1,0 +1,122 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::admin::AdminContext;
+
+/// Account summary for list view.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct AccountListItem {
+    pub id: Uuid,
+    pub name: String,
+    pub owner_email: String,
+    pub is_active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Account detail with usage stats.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct AccountDetail {
+    pub id: Uuid,
+    pub name: String,
+    pub owner_email: String,
+    pub is_active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub key_count: i64,
+    pub message_count: i64,
+}
+
+/// `GET /admin/accounts` — list all accounts.
+pub async fn list(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+) -> Result<Json<Vec<AccountListItem>>, (StatusCode, String)> {
+    let accounts = state
+        .admin_repo()
+        .list_accounts()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(accounts))
+}
+
+/// `GET /admin/accounts/{id}` — account detail with usage stats.
+pub async fn detail(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+) -> Result<Json<AccountDetail>, (StatusCode, String)> {
+    let account = state
+        .admin_repo()
+        .get_account_detail(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "account not found".into()))?;
+
+    Ok(Json(account))
+}
+
+/// Request body for creating an account.
+#[derive(Deserialize)]
+pub struct CreateAccountRequest {
+    pub name: String,
+    pub owner_email: String,
+}
+
+/// `POST /admin/accounts` — create a new account.
+pub async fn create(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Json(body): Json<CreateAccountRequest>,
+) -> Result<(StatusCode, Json<AccountListItem>), (StatusCode, String)> {
+    let account = state
+        .admin_repo()
+        .create_account(&body.name, &body.owner_email)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(account)))
+}
+
+/// Request body for updating an account.
+#[derive(Deserialize)]
+pub struct UpdateAccountRequest {
+    pub is_active: Option<bool>,
+    pub name: Option<String>,
+}
+
+/// `PATCH /admin/accounts/{id}` — update account fields.
+pub async fn update(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateAccountRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .admin_repo()
+        .update_account(id, body.is_active, body.name.as_deref())
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /admin/accounts/{id}` — soft-delete account.
+pub async fn soft_delete(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .admin_repo()
+        .deactivate_account(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/services/chorus-server/src/routes/admin/billing.rs
+++ b/services/chorus-server/src/routes/admin/billing.rs
@@ -1,0 +1,111 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::admin::AdminContext;
+
+/// Billing account summary combining account, subscription, and usage data.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct BillingAccountSummary {
+    pub account_id: Uuid,
+    pub account_name: String,
+    pub plan_slug: String,
+    pub status: String,
+    pub sms_sent: i32,
+    pub sms_quota: i32,
+    pub email_sent: i32,
+    pub email_quota: i32,
+    pub period_end: chrono::DateTime<chrono::Utc>,
+}
+
+/// Billing report with revenue and plan distribution.
+#[derive(Serialize)]
+pub struct BillingReport {
+    pub total_revenue_cents: i64,
+    pub accounts_by_plan: Vec<PlanCount>,
+    pub overage_accounts: Vec<Uuid>,
+}
+
+/// Plan distribution count.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct PlanCount {
+    pub plan_slug: String,
+    pub count: i64,
+}
+
+/// Request body for overriding an account's plan.
+#[derive(Deserialize)]
+pub struct OverridePlanRequest {
+    pub plan_slug: String,
+}
+
+/// Request body for adjusting usage counters.
+#[derive(Deserialize)]
+pub struct AdjustUsageRequest {
+    pub sms_delta: Option<i32>,
+    pub email_delta: Option<i32>,
+}
+
+/// `GET /admin/billing/accounts` — list all accounts with billing status.
+pub async fn list_accounts(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+) -> Result<Json<Vec<BillingAccountSummary>>, (StatusCode, String)> {
+    let accounts = state
+        .admin_repo()
+        .list_billing_accounts()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(accounts))
+}
+
+/// `PATCH /admin/billing/accounts/{id}/plan` — override subscription plan.
+pub async fn override_plan(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+    Json(body): Json<OverridePlanRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .admin_repo()
+        .override_plan(id, &body.plan_slug)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `PATCH /admin/billing/accounts/{id}/usage` — adjust usage counters.
+pub async fn adjust_usage(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+    Json(body): Json<AdjustUsageRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .admin_repo()
+        .adjust_usage(id, body.sms_delta, body.email_delta)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /admin/billing/reports` — billing report.
+pub async fn report(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+) -> Result<Json<BillingReport>, (StatusCode, String)> {
+    let report = state
+        .admin_repo()
+        .billing_report()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(report))
+}

--- a/services/chorus-server/src/routes/admin/dlq.rs
+++ b/services/chorus-server/src/routes/admin/dlq.rs
@@ -84,11 +84,7 @@ pub async fn list(
         }
 
         // Look up message details from DB (no account_id scoping — admin query)
-        if let Ok(Some(msg)) = state
-            .admin_repo()
-            .get_message_by_id(job.message_id)
-            .await
-        {
+        if let Ok(Some(msg)) = state.admin_repo().get_message_by_id(job.message_id).await {
             results.push(DlqMessage {
                 message_id: msg.id,
                 account_id: msg.account_id,
@@ -149,10 +145,7 @@ pub async fn retry_single(
         .ok_or((StatusCode::NOT_FOUND, "message not in DLQ".into()))?;
 
     // Re-enqueue with reset attempt counter
-    let retry_job = SendJob {
-        attempt: 0,
-        ..job
-    };
+    let retry_job = SendJob { attempt: 0, ..job };
     let payload = serde_json::to_string(&retry_job)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -197,10 +190,7 @@ pub async fn retry_batch(
     for mid in &body.message_ids {
         match find_and_remove_from_dlq(&mut conn, *mid).await {
             Ok(Some(job)) => {
-                let retry_job = SendJob {
-                    attempt: 0,
-                    ..job
-                };
+                let retry_job = SendJob { attempt: 0, ..job };
                 let payload = serde_json::to_string(&retry_job)
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
                 redis::cmd("LPUSH")

--- a/services/chorus-server/src/routes/admin/dlq.rs
+++ b/services/chorus-server/src/routes/admin/dlq.rs
@@ -1,0 +1,348 @@
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::admin::AdminContext;
+use crate::db::{DeliveryEvent, Message};
+use crate::queue::{SendJob, DEAD_LETTER_KEY, QUEUE_KEY};
+
+/// DLQ message summary combining Redis job data with DB message data.
+#[derive(Serialize)]
+pub struct DlqMessage {
+    pub message_id: Uuid,
+    pub account_id: Uuid,
+    pub channel: String,
+    pub recipient: String,
+    pub status: String,
+    pub attempts: i32,
+    pub error_message: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// DLQ message detail with retry history.
+#[derive(Serialize)]
+pub struct DlqMessageDetail {
+    pub message: Message,
+    pub delivery_events: Vec<DeliveryEvent>,
+}
+
+/// Query parameters for listing DLQ messages.
+#[derive(Deserialize)]
+pub struct DlqListParams {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+    pub channel: Option<String>,
+    pub account_id: Option<Uuid>,
+}
+
+/// `GET /admin/dlq` — list DLQ messages with optional filters.
+pub async fn list(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Query(params): Query<DlqListParams>,
+) -> Result<Json<Vec<DlqMessage>>, (StatusCode, String)> {
+    let limit = params.limit.unwrap_or(50);
+    let offset = params.offset.unwrap_or(0);
+
+    // Read jobs from Redis DLQ
+    let mut conn = state
+        .redis
+        .get_multiplexed_tokio_connection()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let raw_jobs: Vec<String> = redis::cmd("LRANGE")
+        .arg(DEAD_LETTER_KEY)
+        .arg(offset)
+        .arg(offset + limit - 1)
+        .query_async(&mut conn)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let mut results = Vec::new();
+
+    for raw in &raw_jobs {
+        let job: SendJob = match serde_json::from_str(raw) {
+            Ok(j) => j,
+            Err(_) => continue,
+        };
+
+        // Apply filters
+        if let Some(ref ch) = params.channel {
+            if &job.channel != ch {
+                continue;
+            }
+        }
+        if let Some(aid) = params.account_id {
+            if job.account_id != aid {
+                continue;
+            }
+        }
+
+        // Look up message details from DB (no account_id scoping — admin query)
+        if let Ok(Some(msg)) = state
+            .admin_repo()
+            .get_message_by_id(job.message_id)
+            .await
+        {
+            results.push(DlqMessage {
+                message_id: msg.id,
+                account_id: msg.account_id,
+                channel: msg.channel.clone(),
+                recipient: msg.recipient.clone(),
+                status: msg.status.clone(),
+                attempts: msg.attempts,
+                error_message: msg.error_message.clone(),
+                created_at: msg.created_at,
+            });
+        }
+    }
+
+    Ok(Json(results))
+}
+
+/// `GET /admin/dlq/{message_id}` — DLQ message detail with retry history.
+pub async fn detail(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(message_id): Path<Uuid>,
+) -> Result<Json<DlqMessageDetail>, (StatusCode, String)> {
+    let message = state
+        .admin_repo()
+        .get_message_by_id(message_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "message not found".into()))?;
+
+    let delivery_events = state
+        .message_repo()
+        .get_delivery_events(message_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(DlqMessageDetail {
+        message,
+        delivery_events,
+    }))
+}
+
+/// `POST /admin/dlq/{message_id}/retry` — re-enqueue a single message.
+pub async fn retry_single(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(message_id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let mut conn = state
+        .redis
+        .get_multiplexed_tokio_connection()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Find and remove from DLQ
+    let job = find_and_remove_from_dlq(&mut conn, message_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "message not in DLQ".into()))?;
+
+    // Re-enqueue with reset attempt counter
+    let retry_job = SendJob {
+        attempt: 0,
+        ..job
+    };
+    let payload = serde_json::to_string(&retry_job)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    redis::cmd("LPUSH")
+        .arg(QUEUE_KEY)
+        .arg(payload)
+        .query_async::<i64>(&mut conn)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Request body for batch retry.
+#[derive(Deserialize)]
+pub struct RetryBatchRequest {
+    pub message_ids: Vec<Uuid>,
+}
+
+/// Response for batch retry.
+#[derive(Serialize)]
+pub struct RetryBatchResponse {
+    pub retried: usize,
+    pub not_found: usize,
+}
+
+/// `POST /admin/dlq/retry-batch` — re-enqueue multiple messages.
+pub async fn retry_batch(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Json(body): Json<RetryBatchRequest>,
+) -> Result<Json<RetryBatchResponse>, (StatusCode, String)> {
+    let mut conn = state
+        .redis
+        .get_multiplexed_tokio_connection()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let mut retried = 0;
+    let mut not_found = 0;
+
+    for mid in &body.message_ids {
+        match find_and_remove_from_dlq(&mut conn, *mid).await {
+            Ok(Some(job)) => {
+                let retry_job = SendJob {
+                    attempt: 0,
+                    ..job
+                };
+                let payload = serde_json::to_string(&retry_job)
+                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                redis::cmd("LPUSH")
+                    .arg(QUEUE_KEY)
+                    .arg(payload)
+                    .query_async::<i64>(&mut conn)
+                    .await
+                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                retried += 1;
+            }
+            Ok(None) => not_found += 1,
+            Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        }
+    }
+
+    Ok(Json(RetryBatchResponse { retried, not_found }))
+}
+
+/// `DELETE /admin/dlq/{message_id}` — purge a single message from DLQ.
+pub async fn purge_single(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(message_id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let mut conn = state
+        .redis
+        .get_multiplexed_tokio_connection()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let removed = find_and_remove_from_dlq(&mut conn, message_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if removed.is_none() {
+        return Err((StatusCode::NOT_FOUND, "message not in DLQ".into()));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Query parameters for purge all.
+#[derive(Deserialize)]
+pub struct PurgeParams {
+    pub older_than_days: Option<i64>,
+}
+
+/// Response for purge all.
+#[derive(Serialize)]
+pub struct PurgeResponse {
+    pub purged: i64,
+}
+
+/// `DELETE /admin/dlq/purge` — purge old DLQ messages.
+pub async fn purge_all(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Query(params): Query<PurgeParams>,
+) -> Result<Json<PurgeResponse>, (StatusCode, String)> {
+    let mut conn = state
+        .redis
+        .get_multiplexed_tokio_connection()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if let Some(days) = params.older_than_days {
+        // Selective purge: scan DLQ and remove entries older than N days
+        let cutoff = chrono::Utc::now() - chrono::Duration::days(days);
+        let all_jobs: Vec<String> = redis::cmd("LRANGE")
+            .arg(DEAD_LETTER_KEY)
+            .arg(0)
+            .arg(-1)
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        let mut purged: i64 = 0;
+        for raw in &all_jobs {
+            let job: SendJob = match serde_json::from_str(raw) {
+                Ok(j) => j,
+                Err(_) => continue,
+            };
+            // Check message created_at from DB
+            if let Ok(Some(msg)) = state.admin_repo().get_message_by_id(job.message_id).await {
+                if msg.created_at < cutoff {
+                    let _: i64 = redis::cmd("LREM")
+                        .arg(DEAD_LETTER_KEY)
+                        .arg(1)
+                        .arg(raw)
+                        .query_async(&mut conn)
+                        .await
+                        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                    purged += 1;
+                }
+            }
+        }
+        Ok(Json(PurgeResponse { purged }))
+    } else {
+        // Purge all: get length then DEL
+        let len: i64 = redis::cmd("LLEN")
+            .arg(DEAD_LETTER_KEY)
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        let _: i64 = redis::cmd("DEL")
+            .arg(DEAD_LETTER_KEY)
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        Ok(Json(PurgeResponse { purged: len }))
+    }
+}
+
+/// Find a job in the DLQ by message_id and remove it.
+async fn find_and_remove_from_dlq(
+    conn: &mut redis::aio::MultiplexedConnection,
+    message_id: Uuid,
+) -> anyhow::Result<Option<SendJob>> {
+    let all_jobs: Vec<String> = redis::cmd("LRANGE")
+        .arg(DEAD_LETTER_KEY)
+        .arg(0)
+        .arg(-1)
+        .query_async(conn)
+        .await?;
+
+    for raw in &all_jobs {
+        let job: SendJob = match serde_json::from_str(raw) {
+            Ok(j) => j,
+            Err(_) => continue,
+        };
+        if job.message_id == message_id {
+            redis::cmd("LREM")
+                .arg(DEAD_LETTER_KEY)
+                .arg(1)
+                .arg(raw)
+                .query_async::<i64>(conn)
+                .await?;
+            return Ok(Some(job));
+        }
+    }
+
+    Ok(None)
+}

--- a/services/chorus-server/src/routes/admin/messages.rs
+++ b/services/chorus-server/src/routes/admin/messages.rs
@@ -1,0 +1,73 @@
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::admin::AdminContext;
+use crate::db::{DeliveryEvent, Message};
+
+/// Filters for cross-account message search.
+#[derive(Deserialize)]
+pub struct MessageSearchFilters {
+    pub account_id: Option<Uuid>,
+    pub channel: Option<String>,
+    pub status: Option<String>,
+    pub provider: Option<String>,
+    pub date_from: Option<chrono::DateTime<chrono::Utc>>,
+    pub date_to: Option<chrono::DateTime<chrono::Utc>>,
+    pub recipient: Option<String>,
+    pub min_cost: Option<i64>,
+    pub max_cost: Option<i64>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// Message detail with delivery timeline.
+#[derive(Serialize)]
+pub struct MessageDetail {
+    pub message: Message,
+    pub delivery_events: Vec<DeliveryEvent>,
+}
+
+/// `GET /admin/messages` — search messages across all accounts.
+pub async fn search(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Query(filters): Query<MessageSearchFilters>,
+) -> Result<Json<Vec<Message>>, (StatusCode, String)> {
+    let messages = state
+        .admin_repo()
+        .search_messages(&filters)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(messages))
+}
+
+/// `GET /admin/messages/{id}` — message detail with delivery timeline.
+pub async fn detail(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+) -> Result<Json<MessageDetail>, (StatusCode, String)> {
+    let message = state
+        .admin_repo()
+        .get_message_by_id(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "message not found".into()))?;
+
+    let delivery_events = state
+        .message_repo()
+        .get_delivery_events(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(MessageDetail {
+        message,
+        delivery_events,
+    }))
+}

--- a/services/chorus-server/src/routes/admin/mod.rs
+++ b/services/chorus-server/src/routes/admin/mod.rs
@@ -1,0 +1,26 @@
+pub mod accounts;
+pub mod providers;
+
+use axum::routing::get;
+use axum::Router;
+use std::sync::Arc;
+
+use crate::app::AppState;
+
+/// Build the admin sub-router with all admin endpoints.
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        // Account Management (#34)
+        .route("/accounts", get(accounts::list).post(accounts::create))
+        .route(
+            "/accounts/{id}",
+            get(accounts::detail)
+                .patch(accounts::update)
+                .delete(accounts::soft_delete),
+        )
+        // Provider Config (#35)
+        .route("/providers", get(providers::list_all))
+        .route("/providers/{id}/health", get(providers::health))
+        .route("/providers/{id}", axum::routing::patch(providers::update))
+        .route("/providers/disable", axum::routing::post(providers::bulk_disable))
+}

--- a/services/chorus-server/src/routes/admin/mod.rs
+++ b/services/chorus-server/src/routes/admin/mod.rs
@@ -1,7 +1,10 @@
 pub mod accounts;
+pub mod billing;
+pub mod dlq;
+pub mod messages;
 pub mod providers;
 
-use axum::routing::get;
+use axum::routing::{delete, get, post};
 use axum::Router;
 use std::sync::Arc;
 
@@ -22,5 +25,25 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/providers", get(providers::list_all))
         .route("/providers/{id}/health", get(providers::health))
         .route("/providers/{id}", axum::routing::patch(providers::update))
-        .route("/providers/disable", axum::routing::post(providers::bulk_disable))
+        .route("/providers/disable", post(providers::bulk_disable))
+        // DLQ Management (#36)
+        .route("/dlq", get(dlq::list))
+        .route("/dlq/{message_id}", get(dlq::detail).delete(dlq::purge_single))
+        .route("/dlq/{message_id}/retry", post(dlq::retry_single))
+        .route("/dlq/retry-batch", post(dlq::retry_batch))
+        .route("/dlq/purge", delete(dlq::purge_all))
+        // Message Inspector (#37)
+        .route("/messages", get(messages::search))
+        .route("/messages/{id}", get(messages::detail))
+        // Billing (#38)
+        .route("/billing/accounts", get(billing::list_accounts))
+        .route(
+            "/billing/accounts/{id}/plan",
+            axum::routing::patch(billing::override_plan),
+        )
+        .route(
+            "/billing/accounts/{id}/usage",
+            axum::routing::patch(billing::adjust_usage),
+        )
+        .route("/billing/reports", get(billing::report))
 }

--- a/services/chorus-server/src/routes/admin/mod.rs
+++ b/services/chorus-server/src/routes/admin/mod.rs
@@ -3,6 +3,7 @@ pub mod billing;
 pub mod dlq;
 pub mod messages;
 pub mod providers;
+pub mod webhooks;
 
 use axum::routing::{delete, get, post};
 use axum::Router;
@@ -28,7 +29,10 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/providers/disable", post(providers::bulk_disable))
         // DLQ Management (#36)
         .route("/dlq", get(dlq::list))
-        .route("/dlq/{message_id}", get(dlq::detail).delete(dlq::purge_single))
+        .route(
+            "/dlq/{message_id}",
+            get(dlq::detail).delete(dlq::purge_single),
+        )
         .route("/dlq/{message_id}/retry", post(dlq::retry_single))
         .route("/dlq/retry-batch", post(dlq::retry_batch))
         .route("/dlq/purge", delete(dlq::purge_all))
@@ -46,4 +50,16 @@ pub fn router() -> Router<Arc<AppState>> {
             axum::routing::patch(billing::adjust_usage),
         )
         .route("/billing/reports", get(billing::report))
+        // Webhook Admin (#39)
+        .route("/webhooks", get(webhooks::list_all))
+        .route(
+            "/webhooks/{id}",
+            axum::routing::patch(webhooks::update_status),
+        )
+        .route("/webhooks/{id}/deliveries", get(webhooks::deliveries))
+        .route("/webhooks/{id}/test", post(webhooks::test_webhook))
+        .route(
+            "/webhooks/disable-account/{account_id}",
+            post(webhooks::disable_account),
+        )
 }

--- a/services/chorus-server/src/routes/admin/providers.rs
+++ b/services/chorus-server/src/routes/admin/providers.rs
@@ -1,0 +1,113 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::admin::AdminContext;
+
+/// Provider config summary for admin list view.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct AdminProviderConfig {
+    pub id: Uuid,
+    pub account_id: Uuid,
+    pub channel: String,
+    pub provider: String,
+    pub priority: i32,
+    pub is_active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Provider health summary from recent delivery data.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct ProviderHealth {
+    pub id: Uuid,
+    pub provider: String,
+    pub total_sent: i64,
+    pub total_errors: i64,
+    pub error_rate: f64,
+    pub last_success: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_error: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// `GET /admin/providers` — list all provider configs across accounts.
+pub async fn list_all(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+) -> Result<Json<Vec<AdminProviderConfig>>, (StatusCode, String)> {
+    let configs = state
+        .admin_repo()
+        .list_all_provider_configs()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(configs))
+}
+
+/// `GET /admin/providers/{id}/health` — provider health summary.
+pub async fn health(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ProviderHealth>, (StatusCode, String)> {
+    let health = state
+        .admin_repo()
+        .get_provider_health(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "provider config not found".into()))?;
+
+    Ok(Json(health))
+}
+
+/// Request body for updating a provider config.
+#[derive(Deserialize)]
+pub struct UpdateProviderRequest {
+    pub priority: Option<i32>,
+    pub is_active: Option<bool>,
+}
+
+/// `PATCH /admin/providers/{id}` — update provider config.
+pub async fn update(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateProviderRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .admin_repo()
+        .update_provider_config(id, body.priority, body.is_active)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Request body for bulk disabling a provider.
+#[derive(Deserialize)]
+pub struct BulkDisableRequest {
+    pub provider: String,
+}
+
+/// Response for bulk disable operation.
+#[derive(Serialize)]
+pub struct BulkDisableResponse {
+    pub affected: u64,
+}
+
+/// `POST /admin/providers/disable` — disable a provider across all accounts.
+pub async fn bulk_disable(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Json(body): Json<BulkDisableRequest>,
+) -> Result<Json<BulkDisableResponse>, (StatusCode, String)> {
+    let affected = state
+        .admin_repo()
+        .disable_provider_by_name(&body.provider)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(BulkDisableResponse { affected }))
+}

--- a/services/chorus-server/src/routes/admin/webhooks.rs
+++ b/services/chorus-server/src/routes/admin/webhooks.rs
@@ -1,0 +1,178 @@
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::app::AppState;
+use crate::auth::admin::AdminContext;
+
+/// Webhook summary for admin list view.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct AdminWebhook {
+    pub id: Uuid,
+    pub account_id: Uuid,
+    pub url: String,
+    pub events: Vec<String>,
+    pub is_active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Webhook delivery log entry.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct WebhookDelivery {
+    pub id: Uuid,
+    pub webhook_id: Uuid,
+    pub event: String,
+    pub payload: serde_json::Value,
+    pub response_status: Option<i32>,
+    pub response_body: Option<String>,
+    pub attempt: i32,
+    pub success: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Pagination params for delivery log.
+#[derive(Deserialize)]
+pub struct DeliveryParams {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// Request body for updating webhook status.
+#[derive(Deserialize)]
+pub struct UpdateWebhookRequest {
+    pub is_active: bool,
+}
+
+/// Response for bulk disable.
+#[derive(Serialize)]
+pub struct BulkDisableResponse {
+    pub affected: u64,
+}
+
+/// `GET /admin/webhooks` — list all webhooks across accounts.
+pub async fn list_all(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+) -> Result<Json<Vec<AdminWebhook>>, (StatusCode, String)> {
+    let webhooks = state
+        .admin_repo()
+        .list_all_webhooks()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(webhooks))
+}
+
+/// `GET /admin/webhooks/{id}/deliveries` — webhook delivery log.
+pub async fn deliveries(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+    Query(params): Query<DeliveryParams>,
+) -> Result<Json<Vec<WebhookDelivery>>, (StatusCode, String)> {
+    let limit = params.limit.unwrap_or(50);
+    let offset = params.offset.unwrap_or(0);
+
+    let deliveries = state
+        .admin_repo()
+        .get_webhook_deliveries(id, limit, offset)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(deliveries))
+}
+
+/// `POST /admin/webhooks/{id}/test` — send a test event to webhook.
+pub async fn test_webhook(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    // Look up webhook
+    let webhook = state
+        .admin_repo()
+        .get_webhook_by_id(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "webhook not found".into()))?;
+
+    // Build test payload
+    let test_payload = crate::queue::webhook_dispatch::WebhookPayload {
+        event: "test.ping".into(),
+        message_id: Uuid::nil(),
+        channel: "test".into(),
+        provider: None,
+        status: "test".into(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+
+    let body = serde_json::to_string(&test_payload)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Deliver using HTTP client directly
+    let client = state.http_client();
+    let signature = {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let mut mac = Hmac::<Sha256>::new_from_slice(webhook.secret.as_bytes())
+            .expect("HMAC accepts any key length");
+        mac.update(body.as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    };
+
+    let result = client
+        .post(&webhook.url)
+        .header("Content-Type", "application/json")
+        .header("X-Chorus-Signature", &signature)
+        .header("X-Chorus-Event", "test.ping")
+        .header(
+            "X-Chorus-Timestamp",
+            &chrono::Utc::now().timestamp().to_string(),
+        )
+        .body(body)
+        .send()
+        .await;
+
+    match result {
+        Ok(resp) if resp.status().is_success() => Ok(StatusCode::NO_CONTENT),
+        Ok(resp) => Err((
+            StatusCode::BAD_GATEWAY,
+            format!("webhook returned {}", resp.status()),
+        )),
+        Err(e) => Err((StatusCode::BAD_GATEWAY, format!("webhook error: {e}"))),
+    }
+}
+
+/// `PATCH /admin/webhooks/{id}` — enable/disable a webhook.
+pub async fn update_status(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateWebhookRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .admin_repo()
+        .update_webhook_status(id, body.is_active)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /admin/webhooks/disable-account/{account_id}` — disable all webhooks for an account.
+pub async fn disable_account(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminContext,
+    Path(account_id): Path<Uuid>,
+) -> Result<Json<BulkDisableResponse>, (StatusCode, String)> {
+    let affected = state
+        .admin_repo()
+        .disable_account_webhooks(account_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(BulkDisableResponse { affected }))
+}

--- a/services/chorus-server/src/routes/mod.rs
+++ b/services/chorus-server/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod batch;
 pub mod billing;
 pub mod email;

--- a/services/chorus-server/tests/api_test.rs
+++ b/services/chorus-server/tests/api_test.rs
@@ -670,6 +670,140 @@ async fn webhook_without_auth_returns_401() {
 }
 
 // ---------------------------------------------------------------------------
+// Admin auth tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn admin_accounts_without_auth_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/accounts")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn admin_accounts_with_user_key_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/accounts")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // User API keys (ch_test_) should be rejected by admin endpoint
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn admin_accounts_with_invalid_admin_key_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/accounts")
+                .header("authorization", "Bearer ch_admin_invalid_key")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // NullAdminKeyRepository returns None → 401
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn admin_providers_without_auth_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/providers")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn admin_messages_without_auth_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/messages")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn admin_billing_without_auth_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/billing/accounts")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn admin_webhooks_without_auth_returns_401() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/admin/webhooks")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
 // Billing tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add admin auth system (`ch_admin_` API keys with SHA-256 hash, `AdminContext` extractor)
- Add 6 admin endpoint groups under `/admin/` prefix:
  - **Account management** (#34): CRUD + usage stats
  - **Provider config** (#35): list, health, update, bulk disable
  - **DLQ management** (#36): list, detail, retry, purge (Redis+DB hybrid)
  - **Message inspector** (#37): cross-account search with 9 dynamic filters
  - **Billing admin** (#38): account listing, plan override, usage adjust, reports
  - **Webhook admin** (#39): list, delivery log, test, enable/disable
- Add 2 migrations: `admin_keys` (005) and `webhook_deliveries` (006)
- Add 7 admin auth integration tests (26 total)

## Test plan
- [x] `cargo test --workspace` — 121 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all` — formatted
- [x] `cargo deny check` — advisories ok, licenses ok, sources ok
- [ ] Manual test with real DB: create admin key, verify all endpoints respond correctly
- [ ] Verify Strata dashboard can connect to admin API

Closes #34, closes #35, closes #36, closes #37, closes #38, closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)