### PR TITLE
feat(server): structured logging for Loki integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ base64 = "0.22"
 hex = "0.4"
 
 # Utilities
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8"
 url = "2"

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -201,7 +201,10 @@ pub fn create_router_with_metrics(
         .route("/internal/dns-check", get(routes::internal::dns_check))
         .nest("/admin", routes::admin::router())
         .with_state(state)
-        .layer(axum_middleware::from_fn(crate::middleware::metrics::track));
+        .layer(axum_middleware::from_fn(crate::middleware::metrics::track))
+        .layer(axum_middleware::from_fn(
+            crate::middleware::request_id::inject,
+        ));
 
     if let Some(handle) = metrics_handle {
         router = router.merge(

--- a/services/chorus-server/src/middleware/mod.rs
+++ b/services/chorus-server/src/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod metrics;
+pub mod request_id;

--- a/services/chorus-server/src/middleware/request_id.rs
+++ b/services/chorus-server/src/middleware/request_id.rs
@@ -1,0 +1,30 @@
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use tracing::Instrument;
+use uuid::Uuid;
+
+/// Middleware that generates a unique request ID and wraps the request in a tracing span.
+pub async fn inject(request: axum::extract::Request, next: Next) -> impl IntoResponse {
+    let request_id = request
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned())
+        .unwrap_or_else(|| Uuid::now_v7().to_string());
+
+    let span = tracing::info_span!(
+        "request",
+        request_id = %request_id,
+        method = %request.method(),
+        path = %request.uri().path(),
+    );
+
+    let mut response = next.run(request).instrument(span).await;
+
+    response.headers_mut().insert(
+        "x-request-id",
+        request_id.parse().expect("valid header value"),
+    );
+
+    response
+}

--- a/services/chorus-server/src/queue/delayed.rs
+++ b/services/chorus-server/src/queue/delayed.rs
@@ -1,4 +1,5 @@
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use tracing::Instrument;
 
 /// Spawn the delayed queue poller that moves due jobs back to the main queue.
 pub fn spawn_delayed_poller(redis: redis::Client) {
@@ -29,21 +30,39 @@ async fn poll_delayed_jobs(redis: &redis::Client) -> anyhow::Result<()> {
     super::record_redis_duration!("zrangebyscore", start);
 
     for payload in jobs {
-        // Atomically remove from delayed set — if ZREM returns 0, another poller got it
-        let removed: i64 = redis::cmd("ZREM")
-            .arg(super::DELAYED_KEY)
-            .arg(&payload)
-            .query_async(&mut conn)
-            .await?;
+        let job: super::SendJob = match serde_json::from_str(&payload) {
+            Ok(j) => j,
+            Err(_) => continue,
+        };
 
-        if removed > 0 {
-            redis::cmd("LPUSH")
-                .arg(super::QUEUE_KEY)
+        let span = tracing::info_span!(
+            "requeue_delayed",
+            message_id = %job.message_id,
+            account_id = %job.account_id,
+            attempt = job.attempt,
+        );
+
+        async {
+            // Atomically remove from delayed set — if ZREM returns 0, another poller got it
+            let removed: i64 = redis::cmd("ZREM")
+                .arg(super::DELAYED_KEY)
                 .arg(&payload)
-                .query_async::<i64>(&mut conn)
+                .query_async(&mut conn)
                 .await?;
-            tracing::debug!("moved delayed job back to main queue");
+
+            if removed > 0 {
+                redis::cmd("LPUSH")
+                    .arg(super::QUEUE_KEY)
+                    .arg(&payload)
+                    .query_async::<i64>(&mut conn)
+                    .await?;
+                tracing::debug!("moved delayed job back to main queue");
+            }
+
+            Ok::<_, anyhow::Error>(())
         }
+        .instrument(span)
+        .await?;
     }
 
     Ok(())

--- a/services/chorus-server/src/queue/webhook_dispatch.rs
+++ b/services/chorus-server/src/queue/webhook_dispatch.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::app::AppState;
@@ -45,54 +46,65 @@ pub async fn dispatch_webhooks(
     event: &str,
     payload: &WebhookPayload,
 ) {
-    let webhooks = match state
-        .webhook_repo()
-        .list_by_account_event(account_id, event)
-        .await
-    {
-        Ok(hooks) => hooks,
-        Err(e) => {
-            tracing::error!(error = %e, "failed to load webhooks");
-            return;
-        }
-    };
+    let span = tracing::info_span!(
+        "dispatch_webhooks",
+        account_id = %account_id,
+        event = %event,
+        message_id = %payload.message_id,
+    );
 
-    let body = match serde_json::to_string(payload) {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::error!(error = %e, "failed to serialize webhook payload");
-            return;
-        }
-    };
+    async {
+        let webhooks = match state
+            .webhook_repo()
+            .list_by_account_event(account_id, event)
+            .await
+        {
+            Ok(hooks) => hooks,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to load webhooks");
+                return;
+            }
+        };
 
-    for webhook in webhooks {
-        let delivered = deliver_webhook(
-            state.http_client(),
-            &webhook.url,
-            &webhook.secret,
-            event,
-            &body,
-        )
-        .await;
+        let body = match serde_json::to_string(payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to serialize webhook payload");
+                return;
+            }
+        };
 
-        if !delivered {
-            let job = WebhookJob {
-                webhook_id: webhook.id,
-                url: webhook.url,
-                secret: webhook.secret,
-                event: event.to_string(),
-                body: body.clone(),
-                attempt: 1,
-            };
-            if let Err(e) = schedule_webhook_retry(&state.redis, &job).await {
-                tracing::error!(
-                    webhook_id = %job.webhook_id,
-                    error = %e,
-                    "failed to schedule webhook retry"
-                );
+        for webhook in webhooks {
+            let delivered = deliver_webhook(
+                state.http_client(),
+                &webhook.url,
+                &webhook.secret,
+                event,
+                &body,
+            )
+            .await;
+
+            if !delivered {
+                let job = WebhookJob {
+                    webhook_id: webhook.id,
+                    url: webhook.url,
+                    secret: webhook.secret,
+                    event: event.to_string(),
+                    body: body.clone(),
+                    attempt: 1,
+                };
+                if let Err(e) = schedule_webhook_retry(&state.redis, &job).await {
+                    tracing::error!(
+                        webhook_id = %job.webhook_id,
+                        error = %e,
+                        "failed to schedule webhook retry"
+                    );
+                }
             }
         }
     }
+    .instrument(span)
+    .await;
 }
 
 /// Attempt to deliver a webhook payload to a URL. Returns true on success.
@@ -103,36 +115,42 @@ async fn deliver_webhook(
     event: &str,
     body: &str,
 ) -> bool {
-    let signature = compute_signature(secret, body);
-    let timestamp = Utc::now().timestamp().to_string();
+    let span = tracing::info_span!("deliver_webhook", url = %url, event = %event);
 
-    let result = client
-        .post(url)
-        .header("Content-Type", "application/json")
-        .header("X-Chorus-Signature", &signature)
-        .header("X-Chorus-Event", event)
-        .header("X-Chorus-Timestamp", &timestamp)
-        .body(body.to_string())
-        .send()
-        .await;
+    async {
+        let signature = compute_signature(secret, body);
+        let timestamp = Utc::now().timestamp().to_string();
 
-    match result {
-        Ok(resp) if resp.status().is_success() => {
-            tracing::debug!(url, "webhook delivered");
-            metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "success").increment(1);
-            true
-        }
-        Ok(resp) => {
-            tracing::warn!(url, status = %resp.status(), "webhook delivery failed");
-            metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "failed").increment(1);
-            false
-        }
-        Err(e) => {
-            tracing::warn!(url, error = %e, "webhook HTTP error");
-            metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "error").increment(1);
-            false
+        let result = client
+            .post(url)
+            .header("Content-Type", "application/json")
+            .header("X-Chorus-Signature", &signature)
+            .header("X-Chorus-Event", event)
+            .header("X-Chorus-Timestamp", &timestamp)
+            .body(body.to_string())
+            .send()
+            .await;
+
+        match result {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::debug!("webhook delivered");
+                metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "success").increment(1);
+                true
+            }
+            Ok(resp) => {
+                tracing::warn!(status = %resp.status(), "webhook delivery failed");
+                metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "failed").increment(1);
+                false
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "webhook HTTP error");
+                metrics::counter!("chorus_webhook_deliveries_total", "event" => event.to_string(), "status" => "error").increment(1);
+                false
+            }
         }
     }
+    .instrument(span)
+    .await
 }
 
 /// Schedule a webhook job for retry with exponential backoff.

--- a/services/chorus-server/src/queue/worker.rs
+++ b/services/chorus-server/src/queue/worker.rs
@@ -21,15 +21,18 @@ pub fn spawn_workers(state: Arc<AppState>, config: Arc<Config>, concurrency: usi
     for i in 0..concurrency {
         let state = Arc::clone(&state);
         let config = Arc::clone(&config);
-        tokio::spawn(async move {
-            tracing::info!(worker = i, "queue worker started");
-            loop {
-                if let Err(e) = process_next_job(&state, &config).await {
-                    tracing::error!(worker = i, "worker error: {e}");
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tokio::spawn(
+            async move {
+                tracing::info!("queue worker started");
+                loop {
+                    if let Err(e) = process_next_job(&state, &config).await {
+                        tracing::error!(error = %e, "worker error");
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
                 }
             }
-        });
+            .instrument(tracing::info_span!("worker", worker_id = i)),
+        );
     }
 }
 

--- a/services/chorus-server/src/queue/worker.rs
+++ b/services/chorus-server/src/queue/worker.rs
@@ -2,6 +2,7 @@ use chorus_core::types::{EmailMessage, SmsMessage};
 use chrono::Utc;
 use std::sync::Arc;
 use std::time::Instant;
+use tracing::Instrument;
 
 use crate::app::AppState;
 use crate::config::Config;
@@ -52,217 +53,234 @@ async fn process_next_job(state: &Arc<AppState>, config: &Config) -> anyhow::Res
     };
 
     let job: super::SendJob = serde_json::from_str(&payload)?;
-    let repo = state.message_repo();
 
-    // Load the message from DB
-    let message = repo
-        .find_by_id(job.message_id, job.account_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| anyhow::anyhow!("message {} not found", job.message_id))?;
+    let span = tracing::info_span!(
+        "process_job",
+        message_id = %job.message_id,
+        account_id = %job.account_id,
+        channel = %job.channel,
+        environment = %job.environment,
+        attempt = job.attempt,
+        provider = tracing::field::Empty,
+    );
 
-    metrics::counter!("chorus_messages_processed_total", "channel" => job.channel.clone())
-        .increment(1);
+    async {
+        let repo = state.message_repo();
 
-    // Max retries exceeded → DLQ
-    if job.attempt >= super::MAX_RETRIES {
-        repo.update_status(
-            job.message_id,
-            "failed",
-            None,
-            None,
-            Some("max retries exceeded"),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-        repo.insert_delivery_event(
-            job.message_id,
-            "failed",
-            Some(serde_json::json!({"reason": "max retries exceeded", "attempts": job.attempt})),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-        // Dispatch webhook for failure
-        let webhook_payload = super::webhook_dispatch::WebhookPayload {
-            event: "message.failed".into(),
-            message_id: job.message_id,
-            channel: job.channel.clone(),
-            provider: None,
-            status: "failed".into(),
-            timestamp: Utc::now().to_rfc3339(),
-        };
-        super::webhook_dispatch::dispatch_webhooks(
-            state,
-            job.account_id,
-            "message.failed",
-            &webhook_payload,
-        )
-        .await;
-
-        metrics::counter!("chorus_messages_total", "channel" => job.channel.clone(), "status" => "failed").increment(1);
-        super::dead_letter::push_to_dlq(&state.redis, &job).await?;
-        return Ok(());
-    }
-
-    // Build router based on environment
-    let router = if job.environment == "test" {
-        super::router_builder::build_test_router(&job.channel)
-    } else {
-        // Try per-account config, fall back to env defaults
-        let configs = state
-            .provider_config_repo()
-            .list_by_account_channel(job.account_id, &job.channel)
+        // Load the message from DB
+        let message = repo
+            .find_by_id(job.message_id, job.account_id)
             .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .ok_or_else(|| anyhow::anyhow!("message {} not found", job.message_id))?;
 
-        if configs.is_empty() {
-            super::router_builder::build_router_from_env(config, &job.channel)?
-        } else {
-            super::router_builder::build_router_from_configs(&configs)?
-        }
-    };
+        metrics::counter!("chorus_messages_processed_total", "channel" => job.channel.clone())
+            .increment(1);
 
-    // Send via chorus-core
-    let send_start = Instant::now();
-    let send_result = match job.channel.as_str() {
-        "sms" => {
-            let msg = SmsMessage {
-                to: message.recipient.clone(),
-                body: message.body.clone(),
-                from: message.sender.clone(),
-            };
-            router.send_sms(&msg).await
-        }
-        "email" => {
-            let msg = EmailMessage {
-                to: message.recipient.clone(),
-                subject: message.subject.clone().unwrap_or_default(),
-                html_body: message.body.clone(),
-                text_body: message.body.clone(),
-                from: message.sender.clone(),
-            };
-            router.send_email(&msg).await
-        }
-        _ => anyhow::bail!("unknown channel: {}", job.channel),
-    };
-    let send_duration = send_start.elapsed().as_secs_f64();
-
-    match send_result {
-        Ok(result) => {
-            // Dispatch message.sent (provider accepted)
-            let sent_payload = super::webhook_dispatch::WebhookPayload {
-                event: "message.sent".into(),
-                message_id: job.message_id,
-                channel: job.channel.clone(),
-                provider: Some(result.provider.clone()),
-                status: "sent".into(),
-                timestamp: Utc::now().to_rfc3339(),
-            };
-            super::webhook_dispatch::dispatch_webhooks(
-                state,
-                job.account_id,
-                "message.sent",
-                &sent_payload,
-            )
-            .await;
-
+        // Max retries exceeded → DLQ
+        if job.attempt >= super::MAX_RETRIES {
             repo.update_status(
                 job.message_id,
-                "delivered",
-                Some(&result.provider),
-                Some(&result.message_id),
+                "failed",
                 None,
+                None,
+                Some("max retries exceeded"),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
             repo.insert_delivery_event(
                 job.message_id,
-                "delivered",
-                Some(serde_json::json!({
-                    "provider": result.provider,
-                    "provider_message_id": result.message_id,
-                })),
+                "failed",
+                Some(serde_json::json!({"reason": "max retries exceeded", "attempts": job.attempt})),
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            metrics::counter!("chorus_messages_total", "channel" => job.channel.clone(), "status" => "delivered", "provider" => result.provider.clone()).increment(1);
-
-            metrics::histogram!(
-                "chorus_provider_latency_seconds",
-                "channel" => job.channel.clone(),
-                "provider" => result.provider.clone(),
-            )
-            .record(send_duration);
-
-            let cost = match job.channel.as_str() {
-                "sms" => 7500_u64,
-                "email" => 1000_u64,
-                _ => 0,
-            };
-            metrics::counter!(
-                "chorus_message_cost_microdollars_total",
-                "channel" => job.channel.clone(),
-                "provider" => result.provider.clone(),
-            )
-            .increment(cost);
-
-            // Dispatch webhook
+            // Dispatch webhook for failure
             let webhook_payload = super::webhook_dispatch::WebhookPayload {
-                event: "message.delivered".into(),
+                event: "message.failed".into(),
                 message_id: job.message_id,
                 channel: job.channel.clone(),
-                provider: Some(result.provider.clone()),
-                status: "delivered".into(),
+                provider: None,
+                status: "failed".into(),
                 timestamp: Utc::now().to_rfc3339(),
             };
             super::webhook_dispatch::dispatch_webhooks(
                 state,
                 job.account_id,
-                "message.delivered",
+                "message.failed",
                 &webhook_payload,
             )
             .await;
+
+            metrics::counter!("chorus_messages_total", "channel" => job.channel.clone(), "status" => "failed").increment(1);
+            super::dead_letter::push_to_dlq(&state.redis, &job).await?;
+            return Ok(());
         }
-        Err(e) => {
-            let error_msg = e.to_string();
-            repo.update_status(job.message_id, "retrying", None, None, Some(&error_msg))
+
+        // Build router based on environment
+        let router = if job.environment == "test" {
+            super::router_builder::build_test_router(&job.channel)
+        } else {
+            // Try per-account config, fall back to env defaults
+            let configs = state
+                .provider_config_repo()
+                .list_by_account_channel(job.account_id, &job.channel)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
-            repo.insert_delivery_event(
-                job.message_id,
-                "failed_attempt",
-                Some(serde_json::json!({
-                    "attempt": job.attempt,
-                    "error": error_msg,
-                })),
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            metrics::counter!(
-                "chorus_provider_errors_total",
-                "channel" => job.channel.clone(),
-                "provider" => "unknown",
-            )
-            .increment(1);
+            if configs.is_empty() {
+                super::router_builder::build_router_from_env(config, &job.channel)?
+            } else {
+                super::router_builder::build_router_from_configs(&configs)?
+            }
+        };
 
-            metrics::histogram!(
-                "chorus_provider_latency_seconds",
-                "channel" => job.channel.clone(),
-                "provider" => "unknown",
-            )
-            .record(send_duration);
+        // Send via chorus-core
+        let send_start = Instant::now();
+        let send_result = match job.channel.as_str() {
+            "sms" => {
+                let msg = SmsMessage {
+                    to: message.recipient.clone(),
+                    body: message.body.clone(),
+                    from: message.sender.clone(),
+                };
+                router.send_sms(&msg).await
+            }
+            "email" => {
+                let msg = EmailMessage {
+                    to: message.recipient.clone(),
+                    subject: message.subject.clone().unwrap_or_default(),
+                    html_body: message.body.clone(),
+                    text_body: message.body.clone(),
+                    from: message.sender.clone(),
+                };
+                router.send_email(&msg).await
+            }
+            _ => anyhow::bail!("unknown channel: {}", job.channel),
+        };
+        let send_duration = send_start.elapsed().as_secs_f64();
 
-            // Schedule retry with incremented attempt
-            let retry_job = super::SendJob {
-                attempt: job.attempt + 1,
-                ..job
-            };
-            super::delayed::schedule_retry(&state.redis, &retry_job).await?;
+        match send_result {
+            Ok(result) => {
+                tracing::Span::current().record("provider", result.provider.as_str());
+
+                // Dispatch message.sent (provider accepted)
+                let sent_payload = super::webhook_dispatch::WebhookPayload {
+                    event: "message.sent".into(),
+                    message_id: job.message_id,
+                    channel: job.channel.clone(),
+                    provider: Some(result.provider.clone()),
+                    status: "sent".into(),
+                    timestamp: Utc::now().to_rfc3339(),
+                };
+                super::webhook_dispatch::dispatch_webhooks(
+                    state,
+                    job.account_id,
+                    "message.sent",
+                    &sent_payload,
+                )
+                .await;
+
+                repo.update_status(
+                    job.message_id,
+                    "delivered",
+                    Some(&result.provider),
+                    Some(&result.message_id),
+                    None,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+                repo.insert_delivery_event(
+                    job.message_id,
+                    "delivered",
+                    Some(serde_json::json!({
+                        "provider": result.provider,
+                        "provider_message_id": result.message_id,
+                    })),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+                metrics::counter!("chorus_messages_total", "channel" => job.channel.clone(), "status" => "delivered", "provider" => result.provider.clone()).increment(1);
+
+                metrics::histogram!(
+                    "chorus_provider_latency_seconds",
+                    "channel" => job.channel.clone(),
+                    "provider" => result.provider.clone(),
+                )
+                .record(send_duration);
+
+                let cost = match job.channel.as_str() {
+                    "sms" => 7500_u64,
+                    "email" => 1000_u64,
+                    _ => 0,
+                };
+                metrics::counter!(
+                    "chorus_message_cost_microdollars_total",
+                    "channel" => job.channel.clone(),
+                    "provider" => result.provider.clone(),
+                )
+                .increment(cost);
+
+                // Dispatch webhook
+                let webhook_payload = super::webhook_dispatch::WebhookPayload {
+                    event: "message.delivered".into(),
+                    message_id: job.message_id,
+                    channel: job.channel.clone(),
+                    provider: Some(result.provider.clone()),
+                    status: "delivered".into(),
+                    timestamp: Utc::now().to_rfc3339(),
+                };
+                super::webhook_dispatch::dispatch_webhooks(
+                    state,
+                    job.account_id,
+                    "message.delivered",
+                    &webhook_payload,
+                )
+                .await;
+            }
+            Err(e) => {
+                let error_msg = e.to_string();
+                repo.update_status(job.message_id, "retrying", None, None, Some(&error_msg))
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                repo.insert_delivery_event(
+                    job.message_id,
+                    "failed_attempt",
+                    Some(serde_json::json!({
+                        "attempt": job.attempt,
+                        "error": error_msg,
+                    })),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+                metrics::counter!(
+                    "chorus_provider_errors_total",
+                    "channel" => job.channel.clone(),
+                    "provider" => "unknown",
+                )
+                .increment(1);
+
+                metrics::histogram!(
+                    "chorus_provider_latency_seconds",
+                    "channel" => job.channel.clone(),
+                    "provider" => "unknown",
+                )
+                .record(send_duration);
+
+                // Schedule retry with incremented attempt
+                let retry_job = super::SendJob {
+                    attempt: job.attempt + 1,
+                    ..job
+                };
+                super::delayed::schedule_retry(&state.redis, &retry_job).await?;
+            }
         }
-    }
 
-    Ok(())
+        Ok(())
+    }
+    .instrument(span)
+    .await
 }


### PR DESCRIPTION
## Summary

Closes #40

- Add request ID middleware (UUID v7) with `X-Request-Id` header propagation and tracing span (`request_id`, `method`, `path`)
- Enrich worker job processing with `process_job` span (`message_id`, `account_id`, `channel`, `environment`, `attempt`, `provider`)
- Add `worker_id` span to worker loops for per-worker log correlation
- Add structured spans to webhook dispatch (`account_id`, `event`, `message_id`, `url`)
- Add structured spans to delayed queue poller (`message_id`, `account_id`, `attempt`)

All spans use `tracing::Instrument` for correct async propagation (not `span.enter()` across `.await` points).

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo deny check` — clean
- [ ] Verify JSON log output with `CHORUS_LOG_FORMAT=json` shows structured fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)