### PR TITLE
chore: dev-env override + rustls-webpki bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      DATABASE_URL: postgres://chorus:chorus@postgres:5432/chorus
-      REDIS_URL: redis://redis:6379
+      DATABASE_URL: ${DATABASE_URL:-postgres://chorus:chorus@postgres:5432/chorus}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
       HOST: 0.0.0.0
       PORT: "3000"
       WORKER_CONCURRENCY: "4"


### PR DESCRIPTION
## Summary
- Allow `DATABASE_URL`/`REDIS_URL` override in `docker-compose.yml` via `${VAR:-default}` so local dev can point chorus-server at an external Postgres/Redis without editing the compose file.
- Bump `rustls-webpki` 0.103.12 → 0.103.13 (transitive, patch-level).

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo deny check` passes (advisories, bans, licenses, sources all ok)
- [ ] Manual: `docker compose up` still works with default values (no env override)
- [ ] Manual: `DATABASE_URL=postgres://... docker compose up` honors the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)