### PR TITLE
fix(server): suppression follow-ups (closes #46-#49)

### DIFF
--- a/services/chorus-server/src/db/mod.rs
+++ b/services/chorus-server/src/db/mod.rs
@@ -291,6 +291,14 @@ pub struct NewSuppression {
     pub source: String,
 }
 
+/// Outcome of a suppression `add` call.
+pub struct AddSuppressionResult {
+    /// The canonical row (newly inserted or pre-existing).
+    pub entry: Suppression,
+    /// `true` if this call inserted the row; `false` if it already existed.
+    pub inserted: bool,
+}
+
 /// Suppression list management.
 #[async_trait]
 pub trait SuppressionRepository: Send + Sync {
@@ -302,8 +310,9 @@ pub trait SuppressionRepository: Send + Sync {
         recipient: &str,
     ) -> Result<Option<String>, DbError>;
 
-    /// Insert a suppression. Idempotent: existing rows are left untouched.
-    async fn add(&self, entry: &NewSuppression) -> Result<(), DbError>;
+    /// Insert a suppression idempotently. Returns the canonical row plus a flag
+    /// indicating whether this call performed the insert.
+    async fn add(&self, entry: &NewSuppression) -> Result<AddSuppressionResult, DbError>;
 
     /// Remove a suppression. Returns `true` if a row was deleted.
     async fn remove(

--- a/services/chorus-server/src/db/suppression.rs
+++ b/services/chorus-server/src/db/suppression.rs
@@ -1,8 +1,11 @@
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use super::{DbError, NewSuppression, Pagination, Suppression, SuppressionRepository};
+use super::{
+    AddSuppressionResult, DbError, NewSuppression, Pagination, Suppression, SuppressionRepository,
+};
 
 /// PostgreSQL-backed suppression repository.
 pub struct PgSuppressionRepository {
@@ -37,21 +40,37 @@ impl SuppressionRepository for PgSuppressionRepository {
         Ok(row.map(|(r,)| r))
     }
 
-    async fn add(&self, entry: &NewSuppression) -> Result<(), DbError> {
-        sqlx::query(
+    async fn add(&self, entry: &NewSuppression) -> Result<AddSuppressionResult, DbError> {
+        // Upsert with no-op conflict update so RETURNING * always yields a row.
+        // `xmax = 0` is a Postgres idiom: zero on a freshly inserted row,
+        // non-zero on an updated/conflicted row — distinguishes insert vs hit.
+        let row: (Uuid, String, String, String, String, DateTime<Utc>, bool) = sqlx::query_as(
             "INSERT INTO suppressions (account_id, channel, recipient, reason, source)
              VALUES ($1, $2, $3, $4, $5)
-             ON CONFLICT (account_id, channel, recipient) DO NOTHING",
+             ON CONFLICT (account_id, channel, recipient)
+             DO UPDATE SET account_id = EXCLUDED.account_id
+             RETURNING account_id, channel, recipient, reason, source, created_at, (xmax = 0) AS inserted",
         )
         .bind(entry.account_id)
         .bind(&entry.channel)
         .bind(&entry.recipient)
         .bind(&entry.reason)
         .bind(&entry.source)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await
         .map_err(|e| DbError::Internal(e.into()))?;
-        Ok(())
+
+        Ok(AddSuppressionResult {
+            entry: Suppression {
+                account_id: row.0,
+                channel: row.1,
+                recipient: row.2,
+                reason: row.3,
+                source: row.4,
+                created_at: row.5,
+            },
+            inserted: row.6,
+        })
     }
 
     async fn remove(

--- a/services/chorus-server/src/routes/batch.rs
+++ b/services/chorus-server/src/routes/batch.rs
@@ -58,10 +58,12 @@ pub struct BatchMessageResult {
     pub message_id: Option<Uuid>,
     pub to: String,
     /// `"queued"` (insert + enqueue both succeeded), `"suppressed"`,
+    /// `"invalid"` (recipient failed format validation, e.g. non-E.164 SMS),
     /// `"failed"` (this entry's insert or enqueue failed), or
     /// `"skipped"` (an earlier entry failed; this one was never attempted).
     pub status: &'static str,
-    /// Present when `status == "suppressed"`.
+    /// Present when `status == "suppressed"` (suppression reason)
+    /// or `status == "invalid"` (validation error description).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
@@ -89,14 +91,12 @@ pub async fn send_sms_batch(
 
     // --- Pass 1: suppression check for all recipients ---
     let mut results: Vec<BatchMessageResult> = Vec::with_capacity(req.recipients.len());
-    let mut any_suppressed = false;
 
     for recipient in &req.recipients {
         match crate::suppression::check_suppression(&state, ctx.account_id, "sms", &recipient.to)
             .await
         {
             Err(crate::suppression::SuppressionRejection::Suppressed { reason }) => {
-                any_suppressed = true;
                 results.push(BatchMessageResult {
                     message_id: None,
                     to: recipient.to.clone(),
@@ -105,10 +105,12 @@ pub async fn send_sms_batch(
                 });
             }
             Err(crate::suppression::SuppressionRejection::InvalidRecipient) => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    format!("invalid recipient: {}", recipient.to),
-                ));
+                results.push(BatchMessageResult {
+                    message_id: None,
+                    to: recipient.to.clone(),
+                    status: "invalid",
+                    reason: Some("not a valid E.164 phone number".into()),
+                });
             }
             Err(crate::suppression::SuppressionRejection::Db(e)) => {
                 return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()));
@@ -129,7 +131,7 @@ pub async fn send_sms_batch(
     let mut enqueue_error: Option<String> = None;
 
     for (i, recipient) in req.recipients.iter().enumerate() {
-        if results[i].status == "suppressed" {
+        if results[i].status != "pending" {
             continue;
         }
         if enqueue_error.is_some() {
@@ -175,10 +177,13 @@ pub async fn send_sms_batch(
         results[i].status = "queued";
     }
 
-    let status = if any_suppressed {
-        StatusCode::MULTI_STATUS
-    } else {
+    // 207 when any entry has a non-queued outcome (suppressed/invalid/failed/skipped),
+    // 202 only when all entries successfully queued.
+    let all_queued = results.iter().all(|r| r.status == "queued");
+    let status = if all_queued {
         StatusCode::ACCEPTED
+    } else {
+        StatusCode::MULTI_STATUS
     };
     Ok((
         status,
@@ -204,14 +209,12 @@ pub async fn send_email_batch(
 
     // --- Pass 1: suppression check for all recipients ---
     let mut results: Vec<BatchMessageResult> = Vec::with_capacity(req.recipients.len());
-    let mut any_suppressed = false;
 
     for recipient in &req.recipients {
         match crate::suppression::check_suppression(&state, ctx.account_id, "email", &recipient.to)
             .await
         {
             Err(crate::suppression::SuppressionRejection::Suppressed { reason }) => {
-                any_suppressed = true;
                 results.push(BatchMessageResult {
                     message_id: None,
                     to: recipient.to.clone(),
@@ -220,10 +223,12 @@ pub async fn send_email_batch(
                 });
             }
             Err(crate::suppression::SuppressionRejection::InvalidRecipient) => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    format!("invalid recipient: {}", recipient.to),
-                ));
+                results.push(BatchMessageResult {
+                    message_id: None,
+                    to: recipient.to.clone(),
+                    status: "invalid",
+                    reason: Some("invalid email address".into()),
+                });
             }
             Err(crate::suppression::SuppressionRejection::Db(e)) => {
                 return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()));
@@ -244,7 +249,7 @@ pub async fn send_email_batch(
     let mut enqueue_error: Option<String> = None;
 
     for (i, recipient) in req.recipients.iter().enumerate() {
-        if results[i].status == "suppressed" {
+        if results[i].status != "pending" {
             continue;
         }
         if enqueue_error.is_some() {
@@ -290,10 +295,13 @@ pub async fn send_email_batch(
         results[i].status = "queued";
     }
 
-    let status = if any_suppressed {
-        StatusCode::MULTI_STATUS
-    } else {
+    // 207 when any entry has a non-queued outcome (suppressed/invalid/failed/skipped),
+    // 202 only when all entries successfully queued.
+    let all_queued = results.iter().all(|r| r.status == "queued");
+    let status = if all_queued {
         StatusCode::ACCEPTED
+    } else {
+        StatusCode::MULTI_STATUS
     };
     Ok((
         status,

--- a/services/chorus-server/src/routes/internal.rs
+++ b/services/chorus-server/src/routes/internal.rs
@@ -70,19 +70,12 @@ pub async fn handle_bounce(
         }
     };
 
-    // Write suppression (idempotent), update message status, append delivery event.
-    state
-        .suppression_repo()
-        .add(&crate::db::NewSuppression {
-            account_id: message.account_id,
-            channel: message.channel.clone(),
-            recipient: normalized,
-            reason: "hard_bounce".into(),
-            source: "chorus-mail".into(),
-        })
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
+    // Three sequential writes; chorus-mail's bounce-handler shell `exit 0`s on
+    // curl failure so postfix won't retry. Order matters: write the most
+    // user-critical state (message status + audit trail) first, suppression
+    // last. Worst case if a later write fails: recipient could receive a
+    // re-send (recoverable on the next bounce) — better than message stuck
+    // in `queued` after suppression was already written.
     state
         .message_repo()
         .update_status(message.id, "bounced", None, None, Some(&body.reason))
@@ -99,6 +92,19 @@ pub async fn handle_bounce(
                 "source": "chorus-mail",
             })),
         )
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Discard the returned row + inserted flag; bounce path doesn't surface them.
+    let _ = state
+        .suppression_repo()
+        .add(&crate::db::NewSuppression {
+            account_id: message.account_id,
+            channel: message.channel.clone(),
+            recipient: normalized,
+            reason: "hard_bounce".into(),
+            source: "chorus-mail".into(),
+        })
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 

--- a/services/chorus-server/src/routes/suppressions.rs
+++ b/services/chorus-server/src/routes/suppressions.rs
@@ -81,6 +81,10 @@ pub async fn list_suppressions(
 }
 
 /// `POST /v1/suppressions`
+///
+/// Returns `201 Created` on a fresh insert; `200 OK` if the entry already
+/// existed (idempotent). The response body always echoes the canonical row
+/// from the database, including its real `created_at`.
 pub async fn create_suppression(
     State(state): State<Arc<AppState>>,
     ctx: AccountContext,
@@ -91,27 +95,24 @@ pub async fn create_suppression(
 
     let entry = NewSuppression {
         account_id: ctx.account_id,
-        channel: req.channel.clone(),
-        recipient: normalized.clone(),
+        channel: req.channel,
+        recipient: normalized,
         reason: "manual".into(),
         source: "api".into(),
     };
 
-    state
+    let result = state
         .suppression_repo()
         .add(&entry)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let resp = SuppressionResponse {
-        channel: req.channel,
-        recipient: normalized,
-        reason: "manual".into(),
-        source: "api".into(),
-        created_at: chrono::Utc::now().to_rfc3339(),
+    let status = if result.inserted {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
     };
-
-    Ok((StatusCode::CREATED, Json(resp)))
+    Ok((status, Json(SuppressionResponse::from(result.entry))))
 }
 
 /// `DELETE /v1/suppressions/{channel}/{recipient}`

--- a/services/chorus-server/tests/api_test.rs
+++ b/services/chorus-server/tests/api_test.rs
@@ -12,10 +12,10 @@ use uuid::Uuid;
 use chorus_server::app::{create_router, AppState};
 use chorus_server::config::Config;
 use chorus_server::db::{
-    Account, AccountRepository, ApiKey, ApiKeyRepository, DbError, DeliveryEvent, Message,
-    MessageRepository, NewMessage, NewProviderConfig, NewSuppression, NewWebhook, Pagination,
-    ProviderConfig, ProviderConfigRepository, Suppression, SuppressionRepository, Webhook,
-    WebhookRepository,
+    Account, AccountRepository, AddSuppressionResult, ApiKey, ApiKeyRepository, DbError,
+    DeliveryEvent, Message, MessageRepository, NewMessage, NewProviderConfig, NewSuppression,
+    NewWebhook, Pagination, ProviderConfig, ProviderConfigRepository, Suppression,
+    SuppressionRepository, Webhook, WebhookRepository,
 };
 
 // ---------------------------------------------------------------------------
@@ -278,24 +278,31 @@ impl SuppressionRepository for MockSuppressionRepo {
             .map(|e| e.reason.clone()))
     }
 
-    async fn add(&self, entry: &NewSuppression) -> Result<(), DbError> {
+    async fn add(&self, entry: &NewSuppression) -> Result<AddSuppressionResult, DbError> {
         let mut entries = self.entries.lock().unwrap();
-        let exists = entries.iter().any(|e| {
+        if let Some(existing) = entries.iter().find(|e| {
             e.account_id == entry.account_id
                 && e.channel == entry.channel
                 && e.recipient == entry.recipient
-        });
-        if !exists {
-            entries.push(Suppression {
-                account_id: entry.account_id,
-                channel: entry.channel.clone(),
-                recipient: entry.recipient.clone(),
-                reason: entry.reason.clone(),
-                source: entry.source.clone(),
-                created_at: Utc::now(),
+        }) {
+            return Ok(AddSuppressionResult {
+                entry: existing.clone(),
+                inserted: false,
             });
         }
-        Ok(())
+        let row = Suppression {
+            account_id: entry.account_id,
+            channel: entry.channel.clone(),
+            recipient: entry.recipient.clone(),
+            reason: entry.reason.clone(),
+            source: entry.source.clone(),
+            created_at: Utc::now(),
+        };
+        entries.push(row.clone());
+        Ok(AddSuppressionResult {
+            entry: row,
+            inserted: true,
+        })
     }
 
     async fn remove(
@@ -1422,4 +1429,155 @@ async fn bounce_with_unknown_message_id_returns_200_no_suppression() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     assert!(fx.suppressions.snapshot().is_empty());
+}
+
+#[tokio::test]
+async fn create_suppression_idempotent_returns_200_on_duplicate() {
+    let app = create_router(test_state());
+
+    // First call → 201 Created
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/suppressions")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    r#"{"channel":"email","recipient":"dup@example.com"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::CREATED);
+    let first_body = response_body(first).await;
+    let first_created_at = first_body["created_at"].as_str().unwrap().to_string();
+
+    // Second call → 200 OK (idempotent), same created_at echoed back
+    let second = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/suppressions")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    r#"{"channel":"email","recipient":"dup@example.com"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::OK);
+    let second_body = response_body(second).await;
+    assert_eq!(second_body["created_at"], first_created_at);
+    assert_eq!(second_body["reason"], "manual");
+}
+
+#[tokio::test]
+async fn create_suppression_forces_server_side_reason_and_source() {
+    // Even if a client sends extra fields like `reason`/`source`, the server
+    // must override them. CreateSuppressionRequest only deserializes
+    // `channel` and `recipient`, so unknown fields are silently dropped —
+    // but this test pins the contract.
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/suppressions")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    r#"{"channel":"email","recipient":"forced@example.com","reason":"hard_bounce","source":"chorus-mail"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body = response_body(resp).await;
+    assert_eq!(body["reason"], "manual");
+    assert_eq!(body["source"], "api");
+}
+
+#[tokio::test]
+async fn list_suppressions_filters_by_channel() {
+    let app = create_router(test_state());
+
+    // Seed one email + one sms suppression.
+    for payload in [
+        r#"{"channel":"email","recipient":"e@example.com"}"#,
+        r#"{"channel":"sms","recipient":"+14155552671"}"#,
+    ] {
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/suppressions")
+                    .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/suppressions?channel=email")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_body(resp).await;
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 1);
+    assert_eq!(data[0]["channel"], "email");
+    assert_eq!(data[0]["recipient"], "e@example.com");
+}
+
+#[tokio::test]
+async fn sms_batch_with_invalid_e164_marks_entry_invalid_and_continues() {
+    let app = create_router(test_state());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/sms/send-batch")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(
+                    r#"{"recipients":[
+                        {"to":"+14155552671","body":"hi"},
+                        {"to":"0812345678","body":"bad e164"}
+                    ]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::MULTI_STATUS);
+    let body = response_body(resp).await;
+    let messages = body["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 2);
+    let invalid: Vec<_> = messages
+        .iter()
+        .filter(|m| m["status"] == "invalid")
+        .collect();
+    assert_eq!(invalid.len(), 1);
+    assert_eq!(invalid[0]["to"], "0812345678");
+    assert!(invalid[0]["reason"].as_str().unwrap().contains("E.164"));
 }


### PR DESCRIPTION
## Summary

Closes the four issues from the PR #45 review: #46, #47, #48, #49.

## Changes

### #47 — Bounce handler write-order consistency
Reordered the three writes in `handle_bounce` so the most user-critical state is written first. New order: `update_status('bounced')` → `insert_delivery_event` → `add suppression`. If a later write fails (chorus-mail's bounce-handler shell `exit 0`s on curl error so postfix won't retry), the worst case is now "recipient could receive a re-send" (recoverable on next bounce) instead of "message stuck in `queued` indefinitely after suppression already wrote".

### #46 — POST `/v1/suppressions` returns 200 on duplicate, real `created_at`
- `SuppressionRepository::add` now returns `AddSuppressionResult { entry, inserted }` via the Postgres `xmax = 0` upsert idiom (`INSERT ... ON CONFLICT DO UPDATE SET account_id = EXCLUDED.account_id RETURNING *, (xmax = 0) AS inserted`).
- Route returns **201 Created** on fresh insert, **200 OK** on duplicate. Body always echoes the canonical row from the DB, including the real `created_at`.

### #48 — Three spec-required tests added
- `create_suppression_idempotent_returns_200_on_duplicate` — verifies status code transitions and `created_at` matching.
- `create_suppression_forces_server_side_reason_and_source` — pins the contract that client-supplied `reason`/`source` are ignored.
- `list_suppressions_filters_by_channel` — seeds one email + one sms entry, filters by channel, asserts only the matching entry returns.

### #49 — Batch routes treat `InvalidRecipient` per-entry
Previously a single bad-format entry caused the whole batch to return 400 (regression vs pre-MVP best-effort behavior). Now: each invalid entry gets `status: "invalid"` with a reason describing the validation error, matching how `Suppressed` is handled. Status decision now: 207 on any non-queued outcome (`suppressed`/`invalid`/`failed`/`skipped`); 202 only when every entry queued.

## Test plan

- [x] `cargo test --workspace` — 40 integration + 11 unit, 0 failures (was 36+11; +4 new tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo deny check` — all ok
- [x] **Smoke #46:** POST same recipient twice → 201 then 200, `created_at` identical (verified on real Postgres via podman)
- [x] **Smoke #47:** Bounce flow end-to-end → message status flipped to `bounced`, delivery_event inserted, suppression added (3 writes verified in DB after reorder)
- [x] **Smoke #49:** SMS batch with mixed valid + non-E.164 → 207, valid entries `queued` with `message_id`, invalid entry `status: "invalid"` with reason
- [x] Containers + ports cleaned up after smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)