### PR TITLE
feat(server): B2 — TOTP / authenticator app ($0 vs Twilio $0.013/check)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,47 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +93,18 @@ checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json-diff"
@@ -148,6 +201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +217,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -184,10 +249,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -257,13 +334,17 @@ dependencies = [
 name = "chorus-server"
 version = "0.3.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
  "axum",
+ "base32",
+ "base64",
  "chorus-core",
  "chorus-providers",
  "chrono",
  "dotenvy",
+ "fast_qr",
  "hex",
  "hickory-resolver",
  "hmac",
@@ -280,10 +361,12 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "totp-lite",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -300,6 +383,22 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -357,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +487,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "critical-section"
@@ -426,7 +543,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -434,6 +561,12 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "deadpool"
@@ -552,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -567,6 +700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,16 +720,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast_qr"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f5ea9788036fedaf55f43a2db0ba01eedf47d26fd6852f01e5cf51952571d57"
+dependencies = [
+ "resvg",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "flume"
@@ -611,6 +787,29 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -779,6 +978,26 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -1043,7 +1262,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1185,6 +1404,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,6 +1429,15 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1250,6 +1494,17 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -1312,7 +1567,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -1385,6 +1640,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memo-map"
@@ -1462,6 +1726,16 @@ checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
  "memo-map",
  "serde",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1604,12 +1878,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1692,6 +1972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +2015,31 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1787,6 +2098,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1889,7 +2206,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1922,7 +2239,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1931,7 +2248,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2012,6 +2329,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2367,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsa"
@@ -2051,11 +2400,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2098,6 +2447,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,7 +2491,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2277,6 +2644,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,6 +2675,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -2432,7 +2829,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -2476,7 +2873,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "crc",
@@ -2540,6 +2937,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,6 +2961,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -2593,7 +3009,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2621,10 +3037,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2674,6 +3090,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -2774,6 +3216,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "totp-lite"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e43134db17199f7f721803383ac5854edd0d3d523cc34dba321d6acfbe76c3"
+dependencies = [
+ "digest",
+ "hmac",
+ "sha1",
+ "sha2",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,7 +3249,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2902,6 +3356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,6 +3381,18 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
 name = "unicode-ident"
@@ -2941,10 +3416,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2962,6 +3459,39 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -3122,7 +3652,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3137,6 +3667,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -3475,7 +4011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3510,6 +4046,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yoke"
@@ -3619,3 +4161,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
+]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ sdks/
 └── c/                   # C11 with libcurl (libchorus)
 ```
 
+## Configuration
+
+### `CHORUS_ENCRYPTION_KEY` (required for TOTP)
+
+chorus-server encrypts TOTP secrets at rest with AES-GCM-256. The
+key is sourced from the env var `CHORUS_ENCRYPTION_KEY` and must
+decode to exactly 32 bytes. Required at startup; the server panics
+if missing or malformed.
+
+Generate a development key:
+
+```sh
+head -c 32 /dev/urandom | base64
+```
+
+Set it in your local `.env` (or shell):
+
+```sh
+export CHORUS_ENCRYPTION_KEY="<base64 of 32 bytes>"
+```
+
+For production deployments, source the key from your secret manager
+(AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault, etc.).
+Rotating the key is **not yet supported** — track follow-up B2.2 in
+the roadmap.
+
 ## Development
 
 ```sh

--- a/services/chorus-server/Cargo.toml
+++ b/services/chorus-server/Cargo.toml
@@ -32,6 +32,9 @@ hmac = { version = "0.12", features = ["std"] }
 reqwest = { workspace = true }
 async-trait = { workspace = true }
 hickory-resolver = { workspace = true }
+totp-lite = "2"
+base32 = "0.5"
+urlencoding = "2"
 regex = "1"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false, features = ["http-listener"] }

--- a/services/chorus-server/Cargo.toml
+++ b/services/chorus-server/Cargo.toml
@@ -21,7 +21,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }
+aes-gcm = { workspace = true }
 anyhow = { workspace = true }
+base64 = { workspace = true }
 thiserror = { workspace = true }
 dotenvy = { workspace = true }
 rand = { workspace = true }

--- a/services/chorus-server/Cargo.toml
+++ b/services/chorus-server/Cargo.toml
@@ -35,6 +35,7 @@ hickory-resolver = { workspace = true }
 totp-lite = "2"
 base32 = "0.5"
 urlencoding = "2"
+fast_qr = { version = "0.13", features = ["image"] }
 regex = "1"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false, features = ["http-listener"] }

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -294,6 +294,13 @@ pub fn create_router_with_metrics(
         .route("/internal/bounces", post(routes::internal::handle_bounce))
         .route("/internal/dns-check", get(routes::internal::dns_check))
         .nest("/admin", routes::admin::router())
+        .route("/v1/totp/enroll", post(routes::totp::enroll_totp))
+        .route("/v1/totp/activate", post(routes::totp::activate_totp))
+        .route("/v1/totp/verify", post(routes::totp::verify_totp))
+        .route(
+            "/v1/totp/{user_id}",
+            get(routes::totp::get_totp_status).delete(routes::totp::disenroll_totp),
+        )
         .with_state(state)
         .layer(axum_middleware::from_fn(crate::middleware::metrics::track))
         .layer(axum_middleware::from_fn(

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -13,10 +13,12 @@ use crate::db::provider_config::PgProviderConfigRepository;
 use crate::db::suppression::PgSuppressionRepository;
 use crate::db::verification::PgVerificationRepository;
 use crate::db::webhook::PgWebhookRepository;
+use crate::crypto::Encryptor;
+use crate::db::totp::PgTotpRepository;
 use crate::db::{
     AccountRepository, AdminKeyRepository, AdminRepository, ApiKeyRepository,
     IdempotencyRepository, MessageRepository, PgAdminRepository, ProviderConfigRepository,
-    SuppressionRepository, VerificationRepository, WebhookRepository,
+    SuppressionRepository, TotpRepository, VerificationRepository, WebhookRepository,
 };
 use crate::routes;
 
@@ -46,6 +48,10 @@ pub struct AppState {
     idempotency_repo: Arc<dyn IdempotencyRepository>,
     /// Verification record repository.
     verification_repo: Arc<dyn VerificationRepository>,
+    /// TOTP record repository.
+    totp_repo: Arc<dyn TotpRepository>,
+    /// AES-GCM encryptor for secret-at-rest columns.
+    encryptor: Arc<Encryptor>,
     /// Billing repository.
     billing_repo: Arc<dyn BillingRepository>,
     /// Admin key repository.
@@ -63,6 +69,10 @@ impl AppState {
         let suppression_repo = Arc::new(PgSuppressionRepository::new(db.clone()));
         let idempotency_repo = Arc::new(PgIdempotencyRepository::new(db.clone()));
         let verification_repo = Arc::new(PgVerificationRepository::new(db.clone()));
+        let totp_repo = Arc::new(PgTotpRepository::new(db.clone()));
+        let encryptor = Arc::new(
+            Encryptor::from_env().expect("CHORUS_ENCRYPTION_KEY missing or invalid")
+        );
         let billing_repo = Arc::new(PgBillingRepository::new(db.clone()));
         let admin_repo = Arc::new(PgAdminRepository::new(db.clone()));
         Self {
@@ -79,6 +89,8 @@ impl AppState {
             suppression_repo,
             idempotency_repo,
             verification_repo,
+            totp_repo,
+            encryptor,
             billing_repo,
             admin_repo,
         }
@@ -97,6 +109,8 @@ impl AppState {
         suppression_repo: Arc<dyn SuppressionRepository>,
         idempotency_repo: Arc<dyn IdempotencyRepository>,
         verification_repo: Arc<dyn VerificationRepository>,
+        totp_repo: Arc<dyn TotpRepository>,
+        encryptor: Arc<Encryptor>,
     ) -> Self {
         Self {
             db: None,
@@ -111,6 +125,8 @@ impl AppState {
             suppression_repo,
             idempotency_repo,
             verification_repo,
+            totp_repo,
+            encryptor,
             billing_repo: Arc::new(crate::db::billing::NullBillingRepository),
             admin_key_repo: Arc::new(NullAdminKeyRepository),
             admin_repo: Arc::new(NullAdminRepository),
@@ -155,6 +171,16 @@ impl AppState {
     /// Access the verification repository.
     pub fn verification_repo(&self) -> Arc<dyn VerificationRepository> {
         Arc::clone(&self.verification_repo)
+    }
+
+    /// Access the TOTP repository.
+    pub fn totp_repo(&self) -> Arc<dyn TotpRepository> {
+        Arc::clone(&self.totp_repo)
+    }
+
+    /// Access the encryptor (AES-GCM keyed at startup).
+    pub fn encryptor(&self) -> &Arc<Encryptor> {
+        &self.encryptor
     }
 
     /// Access the billing repository.

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -6,15 +6,15 @@ use sqlx::PgPool;
 use std::sync::Arc;
 
 use crate::config::Config;
+use crate::crypto::Encryptor;
 use crate::db::billing::{BillingRepository, PgBillingRepository};
 use crate::db::idempotency::PgIdempotencyRepository;
 use crate::db::postgres::PgRepository;
 use crate::db::provider_config::PgProviderConfigRepository;
 use crate::db::suppression::PgSuppressionRepository;
+use crate::db::totp::PgTotpRepository;
 use crate::db::verification::PgVerificationRepository;
 use crate::db::webhook::PgWebhookRepository;
-use crate::crypto::Encryptor;
-use crate::db::totp::PgTotpRepository;
 use crate::db::{
     AccountRepository, AdminKeyRepository, AdminRepository, ApiKeyRepository,
     IdempotencyRepository, MessageRepository, PgAdminRepository, ProviderConfigRepository,
@@ -70,9 +70,8 @@ impl AppState {
         let idempotency_repo = Arc::new(PgIdempotencyRepository::new(db.clone()));
         let verification_repo = Arc::new(PgVerificationRepository::new(db.clone()));
         let totp_repo = Arc::new(PgTotpRepository::new(db.clone()));
-        let encryptor = Arc::new(
-            Encryptor::from_env().expect("CHORUS_ENCRYPTION_KEY missing or invalid")
-        );
+        let encryptor =
+            Arc::new(Encryptor::from_env().expect("CHORUS_ENCRYPTION_KEY missing or invalid"));
         let billing_repo = Arc::new(PgBillingRepository::new(db.clone()));
         let admin_repo = Arc::new(PgAdminRepository::new(db.clone()));
         Self {

--- a/services/chorus-server/src/app.rs
+++ b/services/chorus-server/src/app.rs
@@ -301,6 +301,11 @@ pub fn create_router_with_metrics(
             "/v1/totp/{user_id}",
             get(routes::totp::get_totp_status).delete(routes::totp::disenroll_totp),
         )
+        .route(
+            "/v1/totp/backup-codes/regenerate",
+            post(routes::totp::regenerate_backup_codes),
+        )
+        .route("/v1/totp/{user_id}/qr", get(routes::totp::get_totp_qr))
         .with_state(state)
         .layer(axum_middleware::from_fn(crate::middleware::metrics::track))
         .layer(axum_middleware::from_fn(

--- a/services/chorus-server/src/crypto.rs
+++ b/services/chorus-server/src/crypto.rs
@@ -1,0 +1,177 @@
+//! AES-GCM-256 envelope encryption keyed from env `CHORUS_ENCRYPTION_KEY`.
+//!
+//! Blob layout: `nonce(12) || ciphertext || tag(16)`.
+//! See `docs/superpowers/specs/2026-05-19-totp-design.md` §4.1.
+
+use aes_gcm::{
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+    Aes256Gcm, Key, Nonce,
+};
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::STANDARD, Engine};
+
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
+const KEY_LEN: usize = 32;
+
+/// AES-GCM-256 envelope encryption keyed from env `CHORUS_ENCRYPTION_KEY`.
+pub struct Encryptor {
+    cipher: Aes256Gcm,
+}
+
+impl Encryptor {
+    /// Load from `CHORUS_ENCRYPTION_KEY` env var (base64 of 32 random bytes).
+    /// Fail-fast at startup if missing or malformed.
+    pub fn from_env() -> Result<Self> {
+        let b64 = std::env::var("CHORUS_ENCRYPTION_KEY")
+            .map_err(|_| anyhow!("CHORUS_ENCRYPTION_KEY env var not set"))?;
+        let bytes = STANDARD
+            .decode(b64.trim())
+            .map_err(|e| anyhow!("CHORUS_ENCRYPTION_KEY is not valid base64: {e}"))?;
+        if bytes.len() != KEY_LEN {
+            return Err(anyhow!(
+                "CHORUS_ENCRYPTION_KEY must decode to {} bytes, got {}",
+                KEY_LEN,
+                bytes.len()
+            ));
+        }
+        let key = Key::<Aes256Gcm>::from_slice(&bytes);
+        Ok(Self {
+            cipher: Aes256Gcm::new(key),
+        })
+    }
+
+    /// Encrypt plaintext. Returns `nonce(12) || ciphertext || tag(16)`.
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ct = self
+            .cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|e| anyhow!("encryption failed: {e}"))?;
+        let mut blob = Vec::with_capacity(NONCE_LEN + ct.len());
+        blob.extend_from_slice(&nonce);
+        blob.extend_from_slice(&ct);
+        Ok(blob)
+    }
+
+    /// Decrypt a blob produced by `encrypt`. Authentication failure → Err.
+    pub fn decrypt(&self, blob: &[u8]) -> Result<Vec<u8>> {
+        if blob.len() < NONCE_LEN + TAG_LEN {
+            return Err(anyhow!("blob too short ({} bytes)", blob.len()));
+        }
+        let (nonce_bytes, ct) = blob.split_at(NONCE_LEN);
+        let nonce = Nonce::from_slice(nonce_bytes);
+        self.cipher
+            .decrypt(nonce, ct)
+            .map_err(|e| anyhow!("decryption failed: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> Encryptor {
+        let key_bytes = [42u8; KEY_LEN];
+        let key = Key::<Aes256Gcm>::from_slice(&key_bytes);
+        Encryptor {
+            cipher: Aes256Gcm::new(key),
+        }
+    }
+
+    #[test]
+    fn roundtrip_empty() {
+        let enc = fixture();
+        let blob = enc.encrypt(b"").unwrap();
+        assert_eq!(enc.decrypt(&blob).unwrap(), b"");
+    }
+
+    #[test]
+    fn roundtrip_one_byte() {
+        let enc = fixture();
+        let blob = enc.encrypt(b"x").unwrap();
+        assert_eq!(enc.decrypt(&blob).unwrap(), b"x");
+    }
+
+    #[test]
+    fn roundtrip_totp_secret_length() {
+        let enc = fixture();
+        let secret = [0xABu8; 20];
+        let blob = enc.encrypt(&secret).unwrap();
+        assert_eq!(blob.len(), NONCE_LEN + 20 + TAG_LEN);
+        assert_eq!(enc.decrypt(&blob).unwrap(), &secret[..]);
+    }
+
+    #[test]
+    fn decrypt_rejects_short_blob() {
+        let enc = fixture();
+        assert!(enc.decrypt(&[0u8; 27]).is_err());
+    }
+
+    #[test]
+    fn decrypt_rejects_tampered_ciphertext() {
+        let enc = fixture();
+        let mut blob = enc.encrypt(b"hello world").unwrap();
+        let last = blob.len() - 1;
+        blob[last] ^= 0x01;
+        assert!(enc.decrypt(&blob).is_err());
+    }
+
+    #[test]
+    fn decrypt_rejects_wrong_key() {
+        let enc_a = fixture();
+        let key_b = [99u8; KEY_LEN];
+        let enc_b = Encryptor {
+            cipher: Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_b)),
+        };
+        let blob = enc_a.encrypt(b"secret").unwrap();
+        assert!(enc_b.decrypt(&blob).is_err());
+    }
+
+    #[test]
+    fn encrypt_produces_unique_nonces() {
+        let enc = fixture();
+        let mut blobs = std::collections::HashSet::new();
+        for _ in 0..100 {
+            let blob = enc.encrypt(b"same plaintext").unwrap();
+            assert!(blobs.insert(blob), "duplicate blob — nonce not random");
+        }
+    }
+
+    #[test]
+    fn from_env_rejects_missing() {
+        let prev = std::env::var("CHORUS_ENCRYPTION_KEY").ok();
+        std::env::remove_var("CHORUS_ENCRYPTION_KEY");
+        let result = Encryptor::from_env();
+        if let Some(v) = prev {
+            std::env::set_var("CHORUS_ENCRYPTION_KEY", v);
+        }
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_env_rejects_short_key() {
+        let prev = std::env::var("CHORUS_ENCRYPTION_KEY").ok();
+        std::env::set_var("CHORUS_ENCRYPTION_KEY", STANDARD.encode([0u8; 16]));
+        let result = Encryptor::from_env();
+        if let Some(v) = prev {
+            std::env::set_var("CHORUS_ENCRYPTION_KEY", v);
+        } else {
+            std::env::remove_var("CHORUS_ENCRYPTION_KEY");
+        }
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_env_rejects_bad_base64() {
+        let prev = std::env::var("CHORUS_ENCRYPTION_KEY").ok();
+        std::env::set_var("CHORUS_ENCRYPTION_KEY", "not!valid@base64");
+        let result = Encryptor::from_env();
+        if let Some(v) = prev {
+            std::env::set_var("CHORUS_ENCRYPTION_KEY", v);
+        } else {
+            std::env::remove_var("CHORUS_ENCRYPTION_KEY");
+        }
+        assert!(result.is_err());
+    }
+}

--- a/services/chorus-server/src/db/migrations/010_create_totp.sql
+++ b/services/chorus-server/src/db/migrations/010_create_totp.sql
@@ -1,0 +1,34 @@
+-- services/chorus-server/src/db/migrations/010_create_totp.sql
+CREATE TABLE totp_users (
+    account_id        UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    user_id           TEXT NOT NULL CHECK (length(user_id) BETWEEN 1 AND 255),
+    secret            BYTEA NOT NULL,
+    status            TEXT  NOT NULL CHECK (status IN ('pending','active','disabled')),
+    algorithm         TEXT  NOT NULL DEFAULT 'SHA1',
+    digits            SMALLINT NOT NULL DEFAULT 6,
+    period_secs       SMALLINT NOT NULL DEFAULT 30,
+    issuer            TEXT,
+    label             TEXT,
+    last_verified_at  TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    activated_at      TIMESTAMPTZ,
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (account_id, user_id)
+);
+
+CREATE INDEX totp_users_account_status_idx ON totp_users (account_id, status);
+
+CREATE TABLE totp_backup_codes (
+    id          BIGSERIAL PRIMARY KEY,
+    account_id  UUID NOT NULL,
+    user_id     TEXT NOT NULL,
+    code_hash   BYTEA NOT NULL,
+    used_at     TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    FOREIGN KEY (account_id, user_id)
+        REFERENCES totp_users (account_id, user_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX totp_backup_codes_user_idx ON totp_backup_codes (account_id, user_id, used_at);
+CREATE UNIQUE INDEX totp_backup_codes_hash_uniq ON totp_backup_codes (account_id, user_id, code_hash);

--- a/services/chorus-server/src/db/mod.rs
+++ b/services/chorus-server/src/db/mod.rs
@@ -4,6 +4,7 @@ pub mod idempotency;
 pub mod postgres;
 pub mod provider_config;
 pub mod suppression;
+pub mod totp;
 pub mod verification;
 pub mod webhook;
 
@@ -469,4 +470,97 @@ pub trait VerificationRepository: Send + Sync {
 
     /// Cleanup: bulk-mark expired pending rows. Returns count.
     async fn expire_pending(&self, limit: i64) -> Result<u64, DbError>;
+}
+
+// ----- B2: TOTP -----
+
+/// A TOTP enrollment record (one row per user).
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TotpUser {
+    pub account_id: Uuid,
+    pub user_id: String,
+    #[serde(skip)]
+    pub secret: Vec<u8>,
+    pub status: String,
+    pub algorithm: String,
+    pub digits: i16,
+    pub period_secs: i16,
+    pub issuer: Option<String>,
+    pub label: Option<String>,
+    pub last_verified_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub activated_at: Option<DateTime<Utc>>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Parameters for inserting a new pending TOTP user.
+pub struct NewTotpUser {
+    pub account_id: Uuid,
+    pub user_id: String,
+    pub encrypted_secret: Vec<u8>,
+    pub issuer: Option<String>,
+    pub label: Option<String>,
+}
+
+/// A single backup recovery code row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TotpBackupCode {
+    pub id: i64,
+    pub account_id: Uuid,
+    pub user_id: String,
+    pub code_hash: Vec<u8>,
+    pub used_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// TOTP lifecycle + backup-code management.
+#[async_trait]
+pub trait TotpRepository: Send + Sync {
+    /// Insert a new pending TOTP user + N backup codes in one transaction.
+    /// Errors with `Internal` containing "23505" SQLSTATE on PK conflict.
+    async fn enroll(
+        &self,
+        new_user: &NewTotpUser,
+        backup_code_hashes: &[Vec<u8>],
+    ) -> Result<TotpUser, DbError>;
+
+    async fn find(&self, account_id: Uuid, user_id: &str) -> Result<Option<TotpUser>, DbError>;
+
+    /// Set status='active' + activated_at=now() only if currently pending.
+    /// Errors with `NotFound` if not pending.
+    async fn activate(&self, account_id: Uuid, user_id: &str) -> Result<(), DbError>;
+
+    /// Update last_verified_at = now() (only on active rows).
+    async fn touch_last_verified(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+    ) -> Result<(), DbError>;
+
+    /// Set status='disabled' + zero out secret. Returns true if a row was disabled.
+    async fn disenroll(&self, account_id: Uuid, user_id: &str) -> Result<bool, DbError>;
+
+    /// Atomic UPDATE ... WHERE used_at IS NULL ... RETURNING id.
+    /// Returns true if the code was consumed (found and unused).
+    async fn consume_backup_code(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+        code_hash: &[u8],
+    ) -> Result<bool, DbError>;
+
+    /// Count unused backup codes for the low_backup_codes warning.
+    async fn unused_backup_codes_count(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+    ) -> Result<i64, DbError>;
+
+    /// Replace all backup codes (regenerate endpoint): DELETE old + INSERT new in tx.
+    async fn replace_backup_codes(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+        new_hashes: &[Vec<u8>],
+    ) -> Result<(), DbError>;
 }

--- a/services/chorus-server/src/db/mod.rs
+++ b/services/chorus-server/src/db/mod.rs
@@ -531,11 +531,7 @@ pub trait TotpRepository: Send + Sync {
     async fn activate(&self, account_id: Uuid, user_id: &str) -> Result<(), DbError>;
 
     /// Update last_verified_at = now() (only on active rows).
-    async fn touch_last_verified(
-        &self,
-        account_id: Uuid,
-        user_id: &str,
-    ) -> Result<(), DbError>;
+    async fn touch_last_verified(&self, account_id: Uuid, user_id: &str) -> Result<(), DbError>;
 
     /// Set status='disabled' + zero out secret. Returns true if a row was disabled.
     async fn disenroll(&self, account_id: Uuid, user_id: &str) -> Result<bool, DbError>;

--- a/services/chorus-server/src/db/totp.rs
+++ b/services/chorus-server/src/db/totp.rs
@@ -59,19 +59,14 @@ impl TotpRepository for PgTotpRepository {
         Ok(row)
     }
 
-    async fn find(
-        &self,
-        account_id: Uuid,
-        user_id: &str,
-    ) -> Result<Option<TotpUser>, DbError> {
-        let row: Option<TotpUser> = sqlx::query_as(
-            "SELECT * FROM totp_users WHERE account_id = $1 AND user_id = $2",
-        )
-        .bind(account_id)
-        .bind(user_id)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(map_err)?;
+    async fn find(&self, account_id: Uuid, user_id: &str) -> Result<Option<TotpUser>, DbError> {
+        let row: Option<TotpUser> =
+            sqlx::query_as("SELECT * FROM totp_users WHERE account_id = $1 AND user_id = $2")
+                .bind(account_id)
+                .bind(user_id)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(map_err)?;
         Ok(row)
     }
 
@@ -92,11 +87,7 @@ impl TotpRepository for PgTotpRepository {
         Ok(())
     }
 
-    async fn touch_last_verified(
-        &self,
-        account_id: Uuid,
-        user_id: &str,
-    ) -> Result<(), DbError> {
+    async fn touch_last_verified(&self, account_id: Uuid, user_id: &str) -> Result<(), DbError> {
         sqlx::query(
             "UPDATE totp_users SET last_verified_at=now(), updated_at=now()
              WHERE account_id=$1 AND user_id=$2 AND status='active'",
@@ -171,14 +162,12 @@ impl TotpRepository for PgTotpRepository {
         new_hashes: &[Vec<u8>],
     ) -> Result<(), DbError> {
         let mut tx = self.pool.begin().await.map_err(map_err)?;
-        sqlx::query(
-            "DELETE FROM totp_backup_codes WHERE account_id=$1 AND user_id=$2",
-        )
-        .bind(account_id)
-        .bind(user_id)
-        .execute(&mut *tx)
-        .await
-        .map_err(map_err)?;
+        sqlx::query("DELETE FROM totp_backup_codes WHERE account_id=$1 AND user_id=$2")
+            .bind(account_id)
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_err)?;
         for hash in new_hashes {
             sqlx::query(
                 "INSERT INTO totp_backup_codes (account_id, user_id, code_hash)
@@ -233,7 +222,10 @@ mod tests {
     async fn enroll_creates_pending_user_with_backup_codes(pool: PgPool) {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool.clone());
-        let u = repo.enroll(&fixture(acct, "alice"), &hashes(10)).await.unwrap();
+        let u = repo
+            .enroll(&fixture(acct, "alice"), &hashes(10))
+            .await
+            .unwrap();
         assert_eq!(u.status, "pending");
         assert_eq!(u.user_id, "alice");
         let cnt = repo.unused_backup_codes_count(acct, "alice").await.unwrap();
@@ -245,8 +237,13 @@ mod tests {
     async fn enroll_errors_when_user_already_active(pool: PgPool) {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool);
-        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
-        let err = repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap_err();
+        repo.enroll(&fixture(acct, "alice"), &hashes(1))
+            .await
+            .unwrap();
+        let err = repo
+            .enroll(&fixture(acct, "alice"), &hashes(1))
+            .await
+            .unwrap_err();
         assert!(matches!(err, DbError::Internal(_)));
     }
 
@@ -263,7 +260,9 @@ mod tests {
     async fn find_scopes_to_account(pool: PgPool) {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool);
-        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        repo.enroll(&fixture(acct, "alice"), &hashes(1))
+            .await
+            .unwrap();
         let other = Uuid::new_v4();
         assert!(repo.find(other, "alice").await.unwrap().is_none());
         assert!(repo.find(acct, "alice").await.unwrap().is_some());
@@ -274,7 +273,9 @@ mod tests {
     async fn activate_pending_to_active(pool: PgPool) {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool);
-        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        repo.enroll(&fixture(acct, "alice"), &hashes(1))
+            .await
+            .unwrap();
         repo.activate(acct, "alice").await.unwrap();
         let u = repo.find(acct, "alice").await.unwrap().unwrap();
         assert_eq!(u.status, "active");
@@ -286,7 +287,9 @@ mod tests {
     async fn activate_errors_when_not_pending(pool: PgPool) {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool);
-        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        repo.enroll(&fixture(acct, "alice"), &hashes(1))
+            .await
+            .unwrap();
         repo.activate(acct, "alice").await.unwrap();
         let err = repo.activate(acct, "alice").await.unwrap_err();
         assert!(matches!(err, DbError::NotFound));
@@ -297,7 +300,9 @@ mod tests {
     async fn disenroll_clears_secret(pool: PgPool) {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool.clone());
-        repo.enroll(&fixture(acct, "alice"), &hashes(10)).await.unwrap();
+        repo.enroll(&fixture(acct, "alice"), &hashes(10))
+            .await
+            .unwrap();
         assert!(repo.disenroll(acct, "alice").await.unwrap());
 
         let u = repo.find(acct, "alice").await.unwrap().unwrap();
@@ -311,7 +316,9 @@ mod tests {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool);
         let h = vec![0xBB; 32];
-        repo.enroll(&fixture(acct, "alice"), std::slice::from_ref(&h)).await.unwrap();
+        repo.enroll(&fixture(acct, "alice"), std::slice::from_ref(&h))
+            .await
+            .unwrap();
         assert!(repo.consume_backup_code(acct, "alice", &h).await.unwrap());
         assert!(!repo.consume_backup_code(acct, "alice", &h).await.unwrap());
     }
@@ -321,9 +328,14 @@ mod tests {
     async fn consume_backup_code_returns_false_when_unknown(pool: PgPool) {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool);
-        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        repo.enroll(&fixture(acct, "alice"), &hashes(1))
+            .await
+            .unwrap();
         let other = vec![0xCC; 32];
-        assert!(!repo.consume_backup_code(acct, "alice", &other).await.unwrap());
+        assert!(!repo
+            .consume_backup_code(acct, "alice", &other)
+            .await
+            .unwrap());
     }
 
     #[ignore = "requires DATABASE_URL"]
@@ -333,9 +345,16 @@ mod tests {
         let repo = PgTotpRepository::new(pool);
         let hs = hashes(10);
         repo.enroll(&fixture(acct, "alice"), &hs).await.unwrap();
-        repo.consume_backup_code(acct, "alice", &hs[0]).await.unwrap();
-        repo.consume_backup_code(acct, "alice", &hs[1]).await.unwrap();
-        assert_eq!(repo.unused_backup_codes_count(acct, "alice").await.unwrap(), 8);
+        repo.consume_backup_code(acct, "alice", &hs[0])
+            .await
+            .unwrap();
+        repo.consume_backup_code(acct, "alice", &hs[1])
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.unused_backup_codes_count(acct, "alice").await.unwrap(),
+            8
+        );
     }
 
     #[ignore = "requires DATABASE_URL"]
@@ -344,17 +363,32 @@ mod tests {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool);
         let original = hashes(10);
-        repo.enroll(&fixture(acct, "alice"), &original).await.unwrap();
-        repo.consume_backup_code(acct, "alice", &original[0]).await.unwrap();
+        repo.enroll(&fixture(acct, "alice"), &original)
+            .await
+            .unwrap();
+        repo.consume_backup_code(acct, "alice", &original[0])
+            .await
+            .unwrap();
 
         let fresh: Vec<Vec<u8>> = (10..20).map(|i| vec![i as u8; 32]).collect();
-        repo.replace_backup_codes(acct, "alice", &fresh).await.unwrap();
+        repo.replace_backup_codes(acct, "alice", &fresh)
+            .await
+            .unwrap();
 
         // Old codes (including used) gone
-        assert!(!repo.consume_backup_code(acct, "alice", &original[1]).await.unwrap());
+        assert!(!repo
+            .consume_backup_code(acct, "alice", &original[1])
+            .await
+            .unwrap());
         // New codes available
-        assert!(repo.consume_backup_code(acct, "alice", &fresh[0]).await.unwrap());
-        assert_eq!(repo.unused_backup_codes_count(acct, "alice").await.unwrap(), 9);
+        assert!(repo
+            .consume_backup_code(acct, "alice", &fresh[0])
+            .await
+            .unwrap());
+        assert_eq!(
+            repo.unused_backup_codes_count(acct, "alice").await.unwrap(),
+            9
+        );
     }
 
     #[ignore = "requires DATABASE_URL"]
@@ -362,19 +396,19 @@ mod tests {
     async fn cascade_delete_on_account_removal_drops_user_and_codes(pool: PgPool) {
         let acct = seed_account(&pool).await;
         let repo = PgTotpRepository::new(pool.clone());
-        repo.enroll(&fixture(acct, "alice"), &hashes(10)).await.unwrap();
+        repo.enroll(&fixture(acct, "alice"), &hashes(10))
+            .await
+            .unwrap();
         sqlx::query("DELETE FROM accounts WHERE id = $1")
             .bind(acct)
             .execute(&pool)
             .await
             .unwrap();
-        let n: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM totp_users WHERE account_id = $1",
-        )
-        .bind(acct)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM totp_users WHERE account_id = $1")
+            .bind(acct)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
         assert_eq!(n, 0);
     }
 }

--- a/services/chorus-server/src/db/totp.rs
+++ b/services/chorus-server/src/db/totp.rs
@@ -1,0 +1,380 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::{DbError, NewTotpUser, TotpRepository, TotpUser};
+
+pub struct PgTotpRepository {
+    pool: PgPool,
+}
+
+impl PgTotpRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+fn map_err(e: sqlx::Error) -> DbError {
+    DbError::Internal(anyhow::Error::from(e))
+}
+
+#[async_trait]
+impl TotpRepository for PgTotpRepository {
+    async fn enroll(
+        &self,
+        new_user: &NewTotpUser,
+        backup_code_hashes: &[Vec<u8>],
+    ) -> Result<TotpUser, DbError> {
+        let mut tx = self.pool.begin().await.map_err(map_err)?;
+
+        let row: TotpUser = sqlx::query_as(
+            "INSERT INTO totp_users
+                (account_id, user_id, secret, status, issuer, label)
+             VALUES ($1, $2, $3, 'pending', $4, $5)
+             RETURNING *",
+        )
+        .bind(new_user.account_id)
+        .bind(&new_user.user_id)
+        .bind(&new_user.encrypted_secret)
+        .bind(new_user.issuer.as_deref())
+        .bind(new_user.label.as_deref())
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_err)?;
+
+        for hash in backup_code_hashes {
+            sqlx::query(
+                "INSERT INTO totp_backup_codes (account_id, user_id, code_hash)
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(new_user.account_id)
+            .bind(&new_user.user_id)
+            .bind(hash.as_slice())
+            .execute(&mut *tx)
+            .await
+            .map_err(map_err)?;
+        }
+
+        tx.commit().await.map_err(map_err)?;
+        Ok(row)
+    }
+
+    async fn find(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+    ) -> Result<Option<TotpUser>, DbError> {
+        let row: Option<TotpUser> = sqlx::query_as(
+            "SELECT * FROM totp_users WHERE account_id = $1 AND user_id = $2",
+        )
+        .bind(account_id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_err)?;
+        Ok(row)
+    }
+
+    async fn activate(&self, account_id: Uuid, user_id: &str) -> Result<(), DbError> {
+        let result = sqlx::query(
+            "UPDATE totp_users
+             SET status='active', activated_at=now(), updated_at=now()
+             WHERE account_id=$1 AND user_id=$2 AND status='pending'",
+        )
+        .bind(account_id)
+        .bind(user_id)
+        .execute(&self.pool)
+        .await
+        .map_err(map_err)?;
+        if result.rows_affected() == 0 {
+            return Err(DbError::NotFound);
+        }
+        Ok(())
+    }
+
+    async fn touch_last_verified(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+    ) -> Result<(), DbError> {
+        sqlx::query(
+            "UPDATE totp_users SET last_verified_at=now(), updated_at=now()
+             WHERE account_id=$1 AND user_id=$2 AND status='active'",
+        )
+        .bind(account_id)
+        .bind(user_id)
+        .execute(&self.pool)
+        .await
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    async fn disenroll(&self, account_id: Uuid, user_id: &str) -> Result<bool, DbError> {
+        // Zero out the secret with a single 0x00 byte (cannot be empty: secret is NOT NULL).
+        let zero_byte: &[u8] = &[0u8];
+        let result = sqlx::query(
+            "UPDATE totp_users
+             SET status='disabled', secret=$3, updated_at=now()
+             WHERE account_id=$1 AND user_id=$2 AND status IN ('pending','active')",
+        )
+        .bind(account_id)
+        .bind(user_id)
+        .bind(zero_byte)
+        .execute(&self.pool)
+        .await
+        .map_err(map_err)?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn consume_backup_code(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+        code_hash: &[u8],
+    ) -> Result<bool, DbError> {
+        let row: Option<(i64,)> = sqlx::query_as(
+            "UPDATE totp_backup_codes
+             SET used_at = now()
+             WHERE account_id=$1 AND user_id=$2 AND code_hash=$3 AND used_at IS NULL
+             RETURNING id",
+        )
+        .bind(account_id)
+        .bind(user_id)
+        .bind(code_hash)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_err)?;
+        Ok(row.is_some())
+    }
+
+    async fn unused_backup_codes_count(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+    ) -> Result<i64, DbError> {
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM totp_backup_codes
+             WHERE account_id=$1 AND user_id=$2 AND used_at IS NULL",
+        )
+        .bind(account_id)
+        .bind(user_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(map_err)?;
+        Ok(n)
+    }
+
+    async fn replace_backup_codes(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+        new_hashes: &[Vec<u8>],
+    ) -> Result<(), DbError> {
+        let mut tx = self.pool.begin().await.map_err(map_err)?;
+        sqlx::query(
+            "DELETE FROM totp_backup_codes WHERE account_id=$1 AND user_id=$2",
+        )
+        .bind(account_id)
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_err)?;
+        for hash in new_hashes {
+            sqlx::query(
+                "INSERT INTO totp_backup_codes (account_id, user_id, code_hash)
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(account_id)
+            .bind(user_id)
+            .bind(hash.as_slice())
+            .execute(&mut *tx)
+            .await
+            .map_err(map_err)?;
+        }
+        tx.commit().await.map_err(map_err)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{NewTotpUser, TotpRepository};
+
+    async fn seed_account(pool: &PgPool) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO accounts (id, name, owner_email, is_active)
+             VALUES ($1, 'test', 't@x.com', true)",
+        )
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    fn fixture(acct: Uuid, user_id: &str) -> NewTotpUser {
+        NewTotpUser {
+            account_id: acct,
+            user_id: user_id.to_string(),
+            encrypted_secret: vec![0xAA; 48],
+            issuer: Some("Acme".into()),
+            label: Some("Acme:test".into()),
+        }
+    }
+
+    fn hashes(n: usize) -> Vec<Vec<u8>> {
+        (0..n).map(|i| vec![i as u8; 32]).collect()
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn enroll_creates_pending_user_with_backup_codes(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool.clone());
+        let u = repo.enroll(&fixture(acct, "alice"), &hashes(10)).await.unwrap();
+        assert_eq!(u.status, "pending");
+        assert_eq!(u.user_id, "alice");
+        let cnt = repo.unused_backup_codes_count(acct, "alice").await.unwrap();
+        assert_eq!(cnt, 10);
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn enroll_errors_when_user_already_active(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        let err = repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap_err();
+        assert!(matches!(err, DbError::Internal(_)));
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn find_returns_none_for_unknown(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        assert!(repo.find(acct, "ghost").await.unwrap().is_none());
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn find_scopes_to_account(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        let other = Uuid::new_v4();
+        assert!(repo.find(other, "alice").await.unwrap().is_none());
+        assert!(repo.find(acct, "alice").await.unwrap().is_some());
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn activate_pending_to_active(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        repo.activate(acct, "alice").await.unwrap();
+        let u = repo.find(acct, "alice").await.unwrap().unwrap();
+        assert_eq!(u.status, "active");
+        assert!(u.activated_at.is_some());
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn activate_errors_when_not_pending(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        repo.activate(acct, "alice").await.unwrap();
+        let err = repo.activate(acct, "alice").await.unwrap_err();
+        assert!(matches!(err, DbError::NotFound));
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn disenroll_clears_secret(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool.clone());
+        repo.enroll(&fixture(acct, "alice"), &hashes(10)).await.unwrap();
+        assert!(repo.disenroll(acct, "alice").await.unwrap());
+
+        let u = repo.find(acct, "alice").await.unwrap().unwrap();
+        assert_eq!(u.status, "disabled");
+        assert_eq!(u.secret, vec![0x00]);
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn consume_backup_code_marks_used_and_returns_true(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        let h = vec![0xBB; 32];
+        repo.enroll(&fixture(acct, "alice"), std::slice::from_ref(&h)).await.unwrap();
+        assert!(repo.consume_backup_code(acct, "alice", &h).await.unwrap());
+        assert!(!repo.consume_backup_code(acct, "alice", &h).await.unwrap());
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn consume_backup_code_returns_false_when_unknown(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        repo.enroll(&fixture(acct, "alice"), &hashes(1)).await.unwrap();
+        let other = vec![0xCC; 32];
+        assert!(!repo.consume_backup_code(acct, "alice", &other).await.unwrap());
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn unused_backup_codes_count_excludes_used(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        let hs = hashes(10);
+        repo.enroll(&fixture(acct, "alice"), &hs).await.unwrap();
+        repo.consume_backup_code(acct, "alice", &hs[0]).await.unwrap();
+        repo.consume_backup_code(acct, "alice", &hs[1]).await.unwrap();
+        assert_eq!(repo.unused_backup_codes_count(acct, "alice").await.unwrap(), 8);
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn replace_backup_codes_atomically_swaps(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool);
+        let original = hashes(10);
+        repo.enroll(&fixture(acct, "alice"), &original).await.unwrap();
+        repo.consume_backup_code(acct, "alice", &original[0]).await.unwrap();
+
+        let fresh: Vec<Vec<u8>> = (10..20).map(|i| vec![i as u8; 32]).collect();
+        repo.replace_backup_codes(acct, "alice", &fresh).await.unwrap();
+
+        // Old codes (including used) gone
+        assert!(!repo.consume_backup_code(acct, "alice", &original[1]).await.unwrap());
+        // New codes available
+        assert!(repo.consume_backup_code(acct, "alice", &fresh[0]).await.unwrap());
+        assert_eq!(repo.unused_backup_codes_count(acct, "alice").await.unwrap(), 9);
+    }
+
+    #[ignore = "requires DATABASE_URL"]
+    #[sqlx::test(migrations = "./src/db/migrations")]
+    async fn cascade_delete_on_account_removal_drops_user_and_codes(pool: PgPool) {
+        let acct = seed_account(&pool).await;
+        let repo = PgTotpRepository::new(pool.clone());
+        repo.enroll(&fixture(acct, "alice"), &hashes(10)).await.unwrap();
+        sqlx::query("DELETE FROM accounts WHERE id = $1")
+            .bind(acct)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM totp_users WHERE account_id = $1",
+        )
+        .bind(acct)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(n, 0);
+    }
+}

--- a/services/chorus-server/src/lib.rs
+++ b/services/chorus-server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod auth;
 pub mod billing;
 pub mod config;
+pub mod crypto;
 pub mod db;
 pub mod idempotency;
 pub mod metrics;

--- a/services/chorus-server/src/lib.rs
+++ b/services/chorus-server/src/lib.rs
@@ -11,4 +11,5 @@ pub mod otp;
 pub mod queue;
 pub mod routes;
 pub mod suppression;
+pub mod totp;
 pub mod verification;

--- a/services/chorus-server/src/routes/mod.rs
+++ b/services/chorus-server/src/routes/mod.rs
@@ -10,5 +10,6 @@ pub mod otp;
 pub mod provider_configs;
 pub mod sms;
 pub mod suppressions;
+pub mod totp;
 pub mod verifications;
 pub mod webhooks;

--- a/services/chorus-server/src/routes/totp.rs
+++ b/services/chorus-server/src/routes/totp.rs
@@ -90,8 +90,7 @@ pub async fn enroll_totp(
 ) -> Response {
     let start = std::time::Instant::now();
     let response = enroll_totp_inner(state, ctx, headers, body).await;
-    metrics::histogram!(totp::metrics_keys::ENROLL_DURATION)
-        .record(start.elapsed().as_secs_f64());
+    metrics::histogram!(totp::metrics_keys::ENROLL_DURATION).record(start.elapsed().as_secs_f64());
     response
 }
 
@@ -102,7 +101,12 @@ async fn enroll_totp_inner(
     body: Bytes,
 ) -> Response {
     let token = match idempotency::begin(
-        &state, ctx.key_id, &headers, &Method::POST, ENROLL_PATH, &body,
+        &state,
+        ctx.key_id,
+        &headers,
+        &Method::POST,
+        ENROLL_PATH,
+        &body,
     )
     .await
     {
@@ -132,9 +136,13 @@ async fn enroll_totp_inner(
     let user_id = req.user_id.trim().to_string();
 
     let user_id_hash = totp::hash_user_id(&user_id);
-    if let Err(e) =
-        totp::check_rate_limits(&state.redis, ctx.account_id, &user_id_hash, RateLimitKind::Enroll)
-            .await
+    if let Err(e) = totp::check_rate_limits(
+        &state.redis,
+        ctx.account_id,
+        &user_id_hash,
+        RateLimitKind::Enroll,
+    )
+    .await
     {
         return route_totp_error(&state, token, e).await;
     }
@@ -173,8 +181,10 @@ async fn enroll_totp_inner(
         }
     };
     let backup_plaintext = totp::generate_backup_codes();
-    let backup_hashes: Vec<Vec<u8>> =
-        backup_plaintext.iter().map(|c| totp::hash_backup_code(c)).collect();
+    let backup_hashes: Vec<Vec<u8>> = backup_plaintext
+        .iter()
+        .map(|c| totp::hash_backup_code(c))
+        .collect();
 
     let issuer = req.issuer.clone();
     let label = req.label.clone();
@@ -253,7 +263,10 @@ pub async fn activate_totp(
     let user_id_hash = totp::hash_user_id(user_id);
 
     if let Err(e) = totp::check_rate_limits(
-        &state.redis, ctx.account_id, &user_id_hash, RateLimitKind::Activate,
+        &state.redis,
+        ctx.account_id,
+        &user_id_hash,
+        RateLimitKind::Activate,
     )
     .await
     {
@@ -263,23 +276,47 @@ pub async fn activate_totp(
     let user = match state.totp_repo().find(ctx.account_id, user_id).await {
         Ok(Some(u)) => u,
         Ok(None) => return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled"),
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                &e.to_string(),
+            )
+        }
     };
     if user.status != "pending" {
-        return error_response(StatusCode::GONE, "not_pending", "user is not pending activation");
+        return error_response(
+            StatusCode::GONE,
+            "not_pending",
+            "user is not pending activation",
+        );
     }
 
     let secret = match state.encryptor().decrypt(&user.secret) {
         Ok(s) => s,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                &e.to_string(),
+            )
+        }
     };
     let now = unix_now();
     if !totp::verify_totp_with_window(&secret, now, &req.code) {
-        return error_response(StatusCode::UNPROCESSABLE_ENTITY, "incorrect_code", "code did not match");
+        return error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "incorrect_code",
+            "code did not match",
+        );
     }
 
     if let Err(e) = state.totp_repo().activate(ctx.account_id, user_id).await {
-        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string());
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            &e.to_string(),
+        );
     }
     let user = match state.totp_repo().find(ctx.account_id, user_id).await {
         Ok(Some(u)) => u,
@@ -301,8 +338,7 @@ pub async fn verify_totp(
 ) -> Response {
     let start = std::time::Instant::now();
     let response = verify_totp_inner(state, ctx, req).await;
-    metrics::histogram!(totp::metrics_keys::VERIFY_DURATION)
-        .record(start.elapsed().as_secs_f64());
+    metrics::histogram!(totp::metrics_keys::VERIFY_DURATION).record(start.elapsed().as_secs_f64());
     response
 }
 
@@ -322,7 +358,10 @@ async fn verify_totp_inner(
     let user_id_hash = totp::hash_user_id(user_id);
 
     if let Err(e) = totp::check_rate_limits(
-        &state.redis, ctx.account_id, &user_id_hash, RateLimitKind::Verify,
+        &state.redis,
+        ctx.account_id,
+        &user_id_hash,
+        RateLimitKind::Verify,
     )
     .await
     {
@@ -332,7 +371,13 @@ async fn verify_totp_inner(
     let user = match state.totp_repo().find(ctx.account_id, user_id).await {
         Ok(Some(u)) => u,
         Ok(None) => return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled"),
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                &e.to_string(),
+            )
+        }
     };
     if user.status != "active" {
         return error_response(StatusCode::GONE, "not_active", "user is not active");
@@ -346,17 +391,31 @@ async fn verify_totp_inner(
             .await
         {
             Ok(v) => v,
-            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal",
+                    &e.to_string(),
+                )
+            }
         };
         if !ok {
             metrics::counter!(
                 totp::metrics_keys::VERIFIES_TOTAL,
                 "outcome" => "wrong_code",
                 "method" => "backup_code"
-            ).increment(1);
-            return error_response(StatusCode::UNPROCESSABLE_ENTITY, "incorrect_code", "code did not match");
+            )
+            .increment(1);
+            return error_response(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "incorrect_code",
+                "code did not match",
+            );
         }
-        let _ = state.totp_repo().touch_last_verified(ctx.account_id, user_id).await;
+        let _ = state
+            .totp_repo()
+            .touch_last_verified(ctx.account_id, user_id)
+            .await;
         let unused = state
             .totp_repo()
             .unused_backup_codes_count(ctx.account_id, user_id)
@@ -366,7 +425,8 @@ async fn verify_totp_inner(
             totp::metrics_keys::VERIFIES_TOTAL,
             "outcome" => "approved",
             "method" => "backup_code"
-        ).increment(1);
+        )
+        .increment(1);
         metrics::gauge!(totp::metrics_keys::BACKUP_REMAINING).set(unused as f64);
         return Json(VerifyResponse {
             user_id: user.user_id.clone(),
@@ -381,7 +441,13 @@ async fn verify_totp_inner(
 
     let secret = match state.encryptor().decrypt(&user.secret) {
         Ok(s) => s,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                &e.to_string(),
+            )
+        }
     };
     let now = unix_now();
     if !totp::verify_totp_with_window(&secret, now, &req.code) {
@@ -389,10 +455,18 @@ async fn verify_totp_inner(
             totp::metrics_keys::VERIFIES_TOTAL,
             "outcome" => "wrong_code",
             "method" => "totp"
-        ).increment(1);
-        return error_response(StatusCode::UNPROCESSABLE_ENTITY, "incorrect_code", "code did not match");
+        )
+        .increment(1);
+        return error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "incorrect_code",
+            "code did not match",
+        );
     }
-    let _ = state.totp_repo().touch_last_verified(ctx.account_id, user_id).await;
+    let _ = state
+        .totp_repo()
+        .touch_last_verified(ctx.account_id, user_id)
+        .await;
     let unused = state
         .totp_repo()
         .unused_backup_codes_count(ctx.account_id, user_id)
@@ -402,7 +476,8 @@ async fn verify_totp_inner(
         totp::metrics_keys::VERIFIES_TOTAL,
         "outcome" => "approved",
         "method" => "totp"
-    ).increment(1);
+    )
+    .increment(1);
     metrics::gauge!(totp::metrics_keys::BACKUP_REMAINING).set(unused as f64);
     Json(VerifyResponse {
         user_id: user.user_id.clone(),
@@ -428,7 +503,11 @@ pub async fn disenroll_totp(
             "user_id must be 1-255 ASCII printable characters",
         );
     }
-    match state.totp_repo().disenroll(ctx.account_id, user_id.trim()).await {
+    match state
+        .totp_repo()
+        .disenroll(ctx.account_id, user_id.trim())
+        .await
+    {
         Ok(true) => {
             let body = serde_json::json!({"user_id": user_id, "status": "disabled"});
             (StatusCode::OK, Json(body)).into_response()
@@ -438,7 +517,11 @@ pub async fn disenroll_totp(
             "not_found_or_already_disabled",
             "no active TOTP enrollment found",
         ),
-        Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            &e.to_string(),
+        ),
     }
 }
 
@@ -459,7 +542,13 @@ pub async fn get_totp_status(
     let user = match state.totp_repo().find(ctx.account_id, user_id).await {
         Ok(Some(u)) => u,
         Ok(None) => return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled"),
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                &e.to_string(),
+            )
+        }
     };
     let unused = state
         .totp_repo()
@@ -491,7 +580,12 @@ pub async fn regenerate_backup_codes(
     body: Bytes,
 ) -> Response {
     let token = match idempotency::begin(
-        &state, ctx.key_id, &headers, &Method::POST, REGEN_PATH, &body,
+        &state,
+        ctx.key_id,
+        &headers,
+        &Method::POST,
+        REGEN_PATH,
+        &body,
     )
     .await
     {
@@ -521,7 +615,10 @@ pub async fn regenerate_backup_codes(
 
     let user_id_hash = totp::hash_user_id(&user_id);
     if let Err(e) = totp::check_rate_limits(
-        &state.redis, ctx.account_id, &user_id_hash, RateLimitKind::Enroll,
+        &state.redis,
+        ctx.account_id,
+        &user_id_hash,
+        RateLimitKind::Enroll,
     )
     .await
     {
@@ -545,8 +642,10 @@ pub async fn regenerate_backup_codes(
     }
 
     let new_plaintext = totp::generate_backup_codes();
-    let new_hashes: Vec<Vec<u8>> =
-        new_plaintext.iter().map(|c| totp::hash_backup_code(c)).collect();
+    let new_hashes: Vec<Vec<u8>> = new_plaintext
+        .iter()
+        .map(|c| totp::hash_backup_code(c))
+        .collect();
     if let Err(e) = state
         .totp_repo()
         .replace_backup_codes(ctx.account_id, &user_id, &new_hashes)
@@ -582,25 +681,47 @@ pub async fn get_totp_qr(
     let user = match state.totp_repo().find(ctx.account_id, user_id).await {
         Ok(Some(u)) => u,
         Ok(None) => return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled"),
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                &e.to_string(),
+            )
+        }
     };
     if user.status == "disabled" {
         return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled");
     }
     let secret = match state.encryptor().decrypt(&user.secret) {
         Ok(s) => s,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                &e.to_string(),
+            )
+        }
     };
     let issuer = user.issuer.clone().unwrap_or_else(|| "Chorus".to_string());
     let label = user.label.clone().unwrap_or_else(|| user.user_id.clone());
     let otpauth = totp::build_otpauth_uri(&issuer, &label, &totp::base32_no_pad(&secret));
     let png_data_uri = match totp::qr_png_data_uri(&otpauth) {
         Ok(s) => s,
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                &e.to_string(),
+            )
+        }
     };
     use base64::Engine;
-    let b64 = png_data_uri.strip_prefix("data:image/png;base64,").unwrap_or("");
-    let png_bytes = base64::engine::general_purpose::STANDARD.decode(b64).unwrap_or_default();
+    let b64 = png_data_uri
+        .strip_prefix("data:image/png;base64,")
+        .unwrap_or("");
+    let png_bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .unwrap_or_default();
     (
         StatusCode::OK,
         [(axum::http::header::CONTENT_TYPE, "image/png")],
@@ -626,7 +747,10 @@ fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
 
 fn error_json(status: StatusCode, code: &str, message: &str) -> (StatusCode, Bytes) {
     let body = serde_json::json!({ "error": { "code": code, "message": message } });
-    (status, Bytes::from(serde_json::to_vec(&body).unwrap_or_default()))
+    (
+        status,
+        Bytes::from(serde_json::to_vec(&body).unwrap_or_default()),
+    )
 }
 
 async fn route_totp_error(
@@ -647,7 +771,8 @@ async fn route_totp_error(
             }
             let mut resp = (s, b).into_response();
             if let Ok(v) = HeaderValue::from_str(&retry_after_sec.to_string()) {
-                resp.headers_mut().insert(axum::http::header::RETRY_AFTER, v);
+                resp.headers_mut()
+                    .insert(axum::http::header::RETRY_AFTER, v);
             }
             resp
         }
@@ -665,9 +790,11 @@ async fn route_totp_error(
         | TotpError::NotFound
         | TotpError::NotPending
         | TotpError::NotActive
-        | TotpError::IncorrectCode => {
-            error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", "unexpected TotpError variant")
-        }
+        | TotpError::IncorrectCode => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            "unexpected TotpError variant",
+        ),
     }
 }
 
@@ -681,12 +808,25 @@ fn route_totp_error_plain(err: TotpError) -> Response {
                 "TOTP rate limit exceeded",
             );
             if let Ok(v) = HeaderValue::from_str(&retry_after_sec.to_string()) {
-                resp.headers_mut().insert(axum::http::header::RETRY_AFTER, v);
+                resp.headers_mut()
+                    .insert(axum::http::header::RETRY_AFTER, v);
             }
             resp
         }
-        TotpError::Db(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
-        TotpError::Internal(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
-        _ => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", "unexpected TotpError variant"),
+        TotpError::Db(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            &e.to_string(),
+        ),
+        TotpError::Internal(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            &e.to_string(),
+        ),
+        _ => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal",
+            "unexpected TotpError variant",
+        ),
     }
 }

--- a/services/chorus-server/src/routes/totp.rs
+++ b/services/chorus-server/src/routes/totp.rs
@@ -1,0 +1,503 @@
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, HeaderValue, Method, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::app::AppState;
+use crate::auth::api_key::AccountContext;
+use crate::db::{NewTotpUser, TotpUser};
+use crate::idempotency::{self, IdempotencyAction, IdempotencyToken};
+use crate::totp::{self, RateLimitKind, TotpError};
+
+const ENROLL_PATH: &str = "/v1/totp/enroll";
+
+#[derive(Deserialize)]
+pub struct EnrollRequest {
+    pub user_id: String,
+    pub issuer: Option<String>,
+    pub label: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct EnrollResponse {
+    #[serde(flatten)]
+    pub user: TotpUserPublic,
+    pub otpauth_uri: String,
+    pub qr_code_png: String,
+    pub backup_codes: Vec<String>,
+    pub cost_micro: i64,
+}
+
+/// Public view of TotpUser — strips the secret.
+#[derive(Serialize)]
+pub struct TotpUserPublic {
+    pub user_id: String,
+    pub status: String,
+    pub issuer: Option<String>,
+    pub label: Option<String>,
+    pub last_verified_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub activated_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub unused_backup_codes_count: i64,
+}
+
+impl TotpUserPublic {
+    fn from(u: &TotpUser, unused: i64) -> Self {
+        Self {
+            user_id: u.user_id.clone(),
+            status: u.status.clone(),
+            issuer: u.issuer.clone(),
+            label: u.label.clone(),
+            last_verified_at: u.last_verified_at,
+            created_at: u.created_at,
+            activated_at: u.activated_at,
+            unused_backup_codes_count: unused,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ActivateRequest {
+    pub user_id: String,
+    pub code: String,
+}
+
+#[derive(Deserialize)]
+pub struct VerifyRequest {
+    pub user_id: String,
+    pub code: String,
+}
+
+#[derive(Serialize)]
+pub struct VerifyResponse {
+    pub user_id: String,
+    pub status: String,
+    pub verified: bool,
+    pub method: &'static str, // "totp" | "backup_code"
+    pub low_backup_codes: bool,
+    pub cost_micro: i64,
+}
+
+/// POST /v1/totp/enroll
+pub async fn enroll_totp(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let token = match idempotency::begin(
+        &state, ctx.key_id, &headers, &Method::POST, ENROLL_PATH, &body,
+    )
+    .await
+    {
+        IdempotencyAction::Skip => None,
+        IdempotencyAction::Proceed { token } => Some(token),
+        IdempotencyAction::Respond { status, body: b } => {
+            return idempotency::finalize_and_respond(&state, None, status, b).await
+        }
+    };
+
+    let req: EnrollRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            let (s, b) = idempotency::bad_request(e.to_string());
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+    };
+
+    if !totp::is_valid_user_id(&req.user_id) {
+        let (s, b) = error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid_user_id",
+            "user_id must be 1-255 ASCII printable characters",
+        );
+        return idempotency::finalize_and_respond(&state, token, s, b).await;
+    }
+    let user_id = req.user_id.trim().to_string();
+
+    let user_id_hash = totp::hash_user_id(&user_id);
+    if let Err(e) =
+        totp::check_rate_limits(&state.redis, ctx.account_id, &user_id_hash, RateLimitKind::Enroll)
+            .await
+    {
+        return route_totp_error(&state, token, e).await;
+    }
+
+    // Reject if already pending or active.
+    match state.totp_repo().find(ctx.account_id, &user_id).await {
+        Ok(Some(existing)) if existing.status != "disabled" => {
+            let (s, b) = error_json(
+                StatusCode::CONFLICT,
+                "already_enrolled",
+                "user is already enrolled",
+            );
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+        Ok(Some(_)) => {
+            // disabled — re-enroll path: clear old row first
+            if let Err(e) = clear_disabled(&state, ctx.account_id, &user_id).await {
+                let (s, b) = idempotency::internal_error(e.to_string());
+                return idempotency::finalize_and_respond(&state, token, s, b).await;
+            }
+        }
+        Ok(None) => {}
+        Err(e) => {
+            let (s, b) = idempotency::internal_error(e.to_string());
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+    }
+
+    let secret = totp::generate_secret();
+    let encrypted = match state.encryptor().encrypt(&secret) {
+        Ok(b) => b,
+        Err(e) => {
+            let (s, b) = idempotency::internal_error(e.to_string());
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+    };
+    let backup_plaintext = totp::generate_backup_codes();
+    let backup_hashes: Vec<Vec<u8>> =
+        backup_plaintext.iter().map(|c| totp::hash_backup_code(c)).collect();
+
+    let issuer = req.issuer.clone();
+    let label = req.label.clone();
+    let new_user = NewTotpUser {
+        account_id: ctx.account_id,
+        user_id: user_id.clone(),
+        encrypted_secret: encrypted,
+        issuer: issuer.clone(),
+        label: label.clone(),
+    };
+    let user = match state.totp_repo().enroll(&new_user, &backup_hashes).await {
+        Ok(u) => u,
+        Err(e) => {
+            let (s, b) = idempotency::internal_error(e.to_string());
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+    };
+
+    let resolved_issuer = issuer.unwrap_or_else(|| "Chorus".to_string());
+    let resolved_label = label.unwrap_or_else(|| user_id.clone());
+    let secret_b32 = totp::base32_no_pad(&secret);
+    let otpauth = totp::build_otpauth_uri(&resolved_issuer, &resolved_label, &secret_b32);
+    let qr_png = match totp::qr_png_data_uri(&otpauth) {
+        Ok(s) => s,
+        Err(e) => {
+            let (s, b) = idempotency::internal_error(e.to_string());
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+    };
+
+    let response = EnrollResponse {
+        user: TotpUserPublic::from(&user, backup_plaintext.len() as i64),
+        otpauth_uri: otpauth,
+        qr_code_png: qr_png,
+        backup_codes: backup_plaintext,
+        cost_micro: 0,
+    };
+    let bytes = Bytes::from(serde_json::to_vec(&response).unwrap_or_default());
+    idempotency::finalize_and_respond(&state, token, StatusCode::CREATED, bytes).await
+}
+
+async fn clear_disabled(
+    state: &Arc<AppState>,
+    account_id: uuid::Uuid,
+    user_id: &str,
+) -> Result<(), crate::db::DbError> {
+    // The repo's enroll path uses INSERT with PK — we must delete the disabled row first.
+    let pool = match &state.db {
+        Some(p) => p,
+        None => return Ok(()), // tests using mocks won't hit this branch
+    };
+    sqlx::query("DELETE FROM totp_users WHERE account_id=$1 AND user_id=$2")
+        .bind(account_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .map_err(|e| crate::db::DbError::Internal(anyhow::Error::from(e)))?;
+    Ok(())
+}
+
+/// POST /v1/totp/activate
+pub async fn activate_totp(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Json(req): Json<ActivateRequest>,
+) -> Response {
+    if !totp::is_valid_user_id(&req.user_id) {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_user_id",
+            "user_id must be 1-255 ASCII printable characters",
+        );
+    }
+    let user_id = req.user_id.trim();
+    let user_id_hash = totp::hash_user_id(user_id);
+
+    if let Err(e) = totp::check_rate_limits(
+        &state.redis, ctx.account_id, &user_id_hash, RateLimitKind::Activate,
+    )
+    .await
+    {
+        return route_totp_error_plain(e);
+    }
+
+    let user = match state.totp_repo().find(ctx.account_id, user_id).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled"),
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    };
+    if user.status != "pending" {
+        return error_response(StatusCode::GONE, "not_pending", "user is not pending activation");
+    }
+
+    let secret = match state.encryptor().decrypt(&user.secret) {
+        Ok(s) => s,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    };
+    let now = unix_now();
+    if !totp::verify_totp_with_window(&secret, now, &req.code) {
+        return error_response(StatusCode::UNPROCESSABLE_ENTITY, "incorrect_code", "code did not match");
+    }
+
+    if let Err(e) = state.totp_repo().activate(ctx.account_id, user_id).await {
+        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string());
+    }
+    let user = match state.totp_repo().find(ctx.account_id, user_id).await {
+        Ok(Some(u)) => u,
+        _ => user,
+    };
+    let unused = state
+        .totp_repo()
+        .unused_backup_codes_count(ctx.account_id, user_id)
+        .await
+        .unwrap_or(0);
+    (StatusCode::OK, Json(TotpUserPublic::from(&user, unused))).into_response()
+}
+
+/// POST /v1/totp/verify
+pub async fn verify_totp(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Json(req): Json<VerifyRequest>,
+) -> Response {
+    if !totp::is_valid_user_id(&req.user_id) {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_user_id",
+            "user_id must be 1-255 ASCII printable characters",
+        );
+    }
+    let user_id = req.user_id.trim();
+    let user_id_hash = totp::hash_user_id(user_id);
+
+    if let Err(e) = totp::check_rate_limits(
+        &state.redis, ctx.account_id, &user_id_hash, RateLimitKind::Verify,
+    )
+    .await
+    {
+        return route_totp_error_plain(e);
+    }
+
+    let user = match state.totp_repo().find(ctx.account_id, user_id).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled"),
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    };
+    if user.status != "active" {
+        return error_response(StatusCode::GONE, "not_active", "user is not active");
+    }
+
+    if totp::is_backup_code_format(&req.code) {
+        let hash = totp::hash_backup_code(&req.code);
+        let ok = match state
+            .totp_repo()
+            .consume_backup_code(ctx.account_id, user_id, &hash)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        };
+        if !ok {
+            return error_response(StatusCode::UNPROCESSABLE_ENTITY, "incorrect_code", "code did not match");
+        }
+        let _ = state.totp_repo().touch_last_verified(ctx.account_id, user_id).await;
+        let unused = state
+            .totp_repo()
+            .unused_backup_codes_count(ctx.account_id, user_id)
+            .await
+            .unwrap_or(0);
+        return Json(VerifyResponse {
+            user_id: user.user_id.clone(),
+            status: "active".into(),
+            verified: true,
+            method: "backup_code",
+            low_backup_codes: unused < totp::LOW_BACKUP_THRESHOLD,
+            cost_micro: 0,
+        })
+        .into_response();
+    }
+
+    let secret = match state.encryptor().decrypt(&user.secret) {
+        Ok(s) => s,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    };
+    let now = unix_now();
+    if !totp::verify_totp_with_window(&secret, now, &req.code) {
+        return error_response(StatusCode::UNPROCESSABLE_ENTITY, "incorrect_code", "code did not match");
+    }
+    let _ = state.totp_repo().touch_last_verified(ctx.account_id, user_id).await;
+    let unused = state
+        .totp_repo()
+        .unused_backup_codes_count(ctx.account_id, user_id)
+        .await
+        .unwrap_or(0);
+    Json(VerifyResponse {
+        user_id: user.user_id.clone(),
+        status: "active".into(),
+        verified: true,
+        method: "totp",
+        low_backup_codes: unused < totp::LOW_BACKUP_THRESHOLD,
+        cost_micro: 0,
+    })
+    .into_response()
+}
+
+/// DELETE /v1/totp/{user_id}
+pub async fn disenroll_totp(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Path(user_id): Path<String>,
+) -> Response {
+    if !totp::is_valid_user_id(&user_id) {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_user_id",
+            "user_id must be 1-255 ASCII printable characters",
+        );
+    }
+    match state.totp_repo().disenroll(ctx.account_id, user_id.trim()).await {
+        Ok(true) => {
+            let body = serde_json::json!({"user_id": user_id, "status": "disabled"});
+            (StatusCode::OK, Json(body)).into_response()
+        }
+        Ok(false) => error_response(
+            StatusCode::GONE,
+            "not_found_or_already_disabled",
+            "no active TOTP enrollment found",
+        ),
+        Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    }
+}
+
+/// GET /v1/totp/{user_id}
+pub async fn get_totp_status(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Path(user_id): Path<String>,
+) -> Response {
+    if !totp::is_valid_user_id(&user_id) {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_user_id",
+            "user_id must be 1-255 ASCII printable characters",
+        );
+    }
+    let user_id = user_id.trim();
+    let user = match state.totp_repo().find(ctx.account_id, user_id).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled"),
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    };
+    let unused = state
+        .totp_repo()
+        .unused_backup_codes_count(ctx.account_id, user_id)
+        .await
+        .unwrap_or(0);
+    (StatusCode::OK, Json(TotpUserPublic::from(&user, unused))).into_response()
+}
+
+// ---- internal helpers ----
+
+fn unix_now() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    let body = serde_json::json!({ "error": { "code": code, "message": message } });
+    (status, Json(body)).into_response()
+}
+
+fn error_json(status: StatusCode, code: &str, message: &str) -> (StatusCode, Bytes) {
+    let body = serde_json::json!({ "error": { "code": code, "message": message } });
+    (status, Bytes::from(serde_json::to_vec(&body).unwrap_or_default()))
+}
+
+async fn route_totp_error(
+    state: &Arc<AppState>,
+    token: Option<IdempotencyToken>,
+    err: TotpError,
+) -> Response {
+    match err {
+        TotpError::RateLimitedUser { retry_after_sec }
+        | TotpError::RateLimitedAccount { retry_after_sec } => {
+            let (s, b) = error_json(
+                StatusCode::TOO_MANY_REQUESTS,
+                "rate_limited",
+                "TOTP rate limit exceeded",
+            );
+            if let Some(t) = token {
+                idempotency::finalize(state, t, s, &b).await;
+            }
+            let mut resp = (s, b).into_response();
+            if let Ok(v) = HeaderValue::from_str(&retry_after_sec.to_string()) {
+                resp.headers_mut().insert(axum::http::header::RETRY_AFTER, v);
+            }
+            resp
+        }
+        TotpError::Db(e) => {
+            let (s, b) = idempotency::internal_error(e.to_string());
+            idempotency::finalize_and_respond(state, token, s, b).await
+        }
+        TotpError::Internal(e) => {
+            let (s, b) = idempotency::internal_error(e.to_string());
+            idempotency::finalize_and_respond(state, token, s, b).await
+        }
+        // Handler-specific variants not produced by check_rate_limits.
+        TotpError::InvalidUserId
+        | TotpError::AlreadyEnrolled
+        | TotpError::NotFound
+        | TotpError::NotPending
+        | TotpError::NotActive
+        | TotpError::IncorrectCode => {
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", "unexpected TotpError variant")
+        }
+    }
+}
+
+fn route_totp_error_plain(err: TotpError) -> Response {
+    match err {
+        TotpError::RateLimitedUser { retry_after_sec }
+        | TotpError::RateLimitedAccount { retry_after_sec } => {
+            let mut resp = error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                "rate_limited",
+                "TOTP rate limit exceeded",
+            );
+            if let Ok(v) = HeaderValue::from_str(&retry_after_sec.to_string()) {
+                resp.headers_mut().insert(axum::http::header::RETRY_AFTER, v);
+            }
+            resp
+        }
+        TotpError::Db(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        TotpError::Internal(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+        _ => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", "unexpected TotpError variant"),
+    }
+}

--- a/services/chorus-server/src/routes/totp.rs
+++ b/services/chorus-server/src/routes/totp.rs
@@ -88,6 +88,19 @@ pub async fn enroll_totp(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
+    let start = std::time::Instant::now();
+    let response = enroll_totp_inner(state, ctx, headers, body).await;
+    metrics::histogram!(totp::metrics_keys::ENROLL_DURATION)
+        .record(start.elapsed().as_secs_f64());
+    response
+}
+
+async fn enroll_totp_inner(
+    state: Arc<AppState>,
+    ctx: AccountContext,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
     let token = match idempotency::begin(
         &state, ctx.key_id, &headers, &Method::POST, ENROLL_PATH, &body,
     )
@@ -129,6 +142,7 @@ pub async fn enroll_totp(
     // Reject if already pending or active.
     match state.totp_repo().find(ctx.account_id, &user_id).await {
         Ok(Some(existing)) if existing.status != "disabled" => {
+            metrics::counter!(totp::metrics_keys::ENROLLMENTS_TOTAL, "outcome" => "already_enrolled").increment(1);
             let (s, b) = error_json(
                 StatusCode::CONFLICT,
                 "already_enrolled",
@@ -199,6 +213,7 @@ pub async fn enroll_totp(
         cost_micro: 0,
     };
     let bytes = Bytes::from(serde_json::to_vec(&response).unwrap_or_default());
+    metrics::counter!(totp::metrics_keys::ENROLLMENTS_TOTAL, "outcome" => "created").increment(1);
     idempotency::finalize_and_respond(&state, token, StatusCode::CREATED, bytes).await
 }
 
@@ -284,6 +299,18 @@ pub async fn verify_totp(
     ctx: AccountContext,
     Json(req): Json<VerifyRequest>,
 ) -> Response {
+    let start = std::time::Instant::now();
+    let response = verify_totp_inner(state, ctx, req).await;
+    metrics::histogram!(totp::metrics_keys::VERIFY_DURATION)
+        .record(start.elapsed().as_secs_f64());
+    response
+}
+
+async fn verify_totp_inner(
+    state: Arc<AppState>,
+    ctx: AccountContext,
+    req: VerifyRequest,
+) -> Response {
     if !totp::is_valid_user_id(&req.user_id) {
         return error_response(
             StatusCode::BAD_REQUEST,
@@ -322,6 +349,11 @@ pub async fn verify_totp(
             Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
         };
         if !ok {
+            metrics::counter!(
+                totp::metrics_keys::VERIFIES_TOTAL,
+                "outcome" => "wrong_code",
+                "method" => "backup_code"
+            ).increment(1);
             return error_response(StatusCode::UNPROCESSABLE_ENTITY, "incorrect_code", "code did not match");
         }
         let _ = state.totp_repo().touch_last_verified(ctx.account_id, user_id).await;
@@ -330,6 +362,12 @@ pub async fn verify_totp(
             .unused_backup_codes_count(ctx.account_id, user_id)
             .await
             .unwrap_or(0);
+        metrics::counter!(
+            totp::metrics_keys::VERIFIES_TOTAL,
+            "outcome" => "approved",
+            "method" => "backup_code"
+        ).increment(1);
+        metrics::gauge!(totp::metrics_keys::BACKUP_REMAINING).set(unused as f64);
         return Json(VerifyResponse {
             user_id: user.user_id.clone(),
             status: "active".into(),
@@ -347,6 +385,11 @@ pub async fn verify_totp(
     };
     let now = unix_now();
     if !totp::verify_totp_with_window(&secret, now, &req.code) {
+        metrics::counter!(
+            totp::metrics_keys::VERIFIES_TOTAL,
+            "outcome" => "wrong_code",
+            "method" => "totp"
+        ).increment(1);
         return error_response(StatusCode::UNPROCESSABLE_ENTITY, "incorrect_code", "code did not match");
     }
     let _ = state.totp_repo().touch_last_verified(ctx.account_id, user_id).await;
@@ -355,6 +398,12 @@ pub async fn verify_totp(
         .unused_backup_codes_count(ctx.account_id, user_id)
         .await
         .unwrap_or(0);
+    metrics::counter!(
+        totp::metrics_keys::VERIFIES_TOTAL,
+        "outcome" => "approved",
+        "method" => "totp"
+    ).increment(1);
+    metrics::gauge!(totp::metrics_keys::BACKUP_REMAINING).set(unused as f64);
     Json(VerifyResponse {
         user_id: user.user_id.clone(),
         status: "active".into(),

--- a/services/chorus-server/src/routes/totp.rs
+++ b/services/chorus-server/src/routes/totp.rs
@@ -420,6 +420,146 @@ pub async fn get_totp_status(
     (StatusCode::OK, Json(TotpUserPublic::from(&user, unused))).into_response()
 }
 
+const REGEN_PATH: &str = "/v1/totp/backup-codes/regenerate";
+
+#[derive(Deserialize)]
+pub struct RegenerateRequest {
+    pub user_id: String,
+}
+
+#[derive(Serialize)]
+pub struct RegenerateResponse {
+    pub user_id: String,
+    pub backup_codes: Vec<String>,
+    pub cost_micro: i64,
+}
+
+/// POST /v1/totp/backup-codes/regenerate
+pub async fn regenerate_backup_codes(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let token = match idempotency::begin(
+        &state, ctx.key_id, &headers, &Method::POST, REGEN_PATH, &body,
+    )
+    .await
+    {
+        IdempotencyAction::Skip => None,
+        IdempotencyAction::Proceed { token } => Some(token),
+        IdempotencyAction::Respond { status, body: b } => {
+            return idempotency::finalize_and_respond(&state, None, status, b).await
+        }
+    };
+
+    let req: RegenerateRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            let (s, b) = idempotency::bad_request(e.to_string());
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+    };
+    if !totp::is_valid_user_id(&req.user_id) {
+        let (s, b) = error_json(
+            StatusCode::BAD_REQUEST,
+            "invalid_user_id",
+            "user_id must be 1-255 ASCII printable characters",
+        );
+        return idempotency::finalize_and_respond(&state, token, s, b).await;
+    }
+    let user_id = req.user_id.trim().to_string();
+
+    let user_id_hash = totp::hash_user_id(&user_id);
+    if let Err(e) = totp::check_rate_limits(
+        &state.redis, ctx.account_id, &user_id_hash, RateLimitKind::Enroll,
+    )
+    .await
+    {
+        return route_totp_error(&state, token, e).await;
+    }
+
+    let user = match state.totp_repo().find(ctx.account_id, &user_id).await {
+        Ok(Some(u)) => u,
+        Ok(None) => {
+            let (s, b) = error_json(StatusCode::NOT_FOUND, "not_found", "user not enrolled");
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+        Err(e) => {
+            let (s, b) = idempotency::internal_error(e.to_string());
+            return idempotency::finalize_and_respond(&state, token, s, b).await;
+        }
+    };
+    if user.status != "active" {
+        let (s, b) = error_json(StatusCode::GONE, "not_active", "user is not active");
+        return idempotency::finalize_and_respond(&state, token, s, b).await;
+    }
+
+    let new_plaintext = totp::generate_backup_codes();
+    let new_hashes: Vec<Vec<u8>> =
+        new_plaintext.iter().map(|c| totp::hash_backup_code(c)).collect();
+    if let Err(e) = state
+        .totp_repo()
+        .replace_backup_codes(ctx.account_id, &user_id, &new_hashes)
+        .await
+    {
+        let (s, b) = idempotency::internal_error(e.to_string());
+        return idempotency::finalize_and_respond(&state, token, s, b).await;
+    }
+
+    let response = RegenerateResponse {
+        user_id: user_id.clone(),
+        backup_codes: new_plaintext,
+        cost_micro: 0,
+    };
+    let bytes = Bytes::from(serde_json::to_vec(&response).unwrap_or_default());
+    idempotency::finalize_and_respond(&state, token, StatusCode::OK, bytes).await
+}
+
+/// GET /v1/totp/{user_id}/qr — raw image/png response
+pub async fn get_totp_qr(
+    State(state): State<Arc<AppState>>,
+    ctx: AccountContext,
+    Path(user_id): Path<String>,
+) -> Response {
+    if !totp::is_valid_user_id(&user_id) {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_user_id",
+            "user_id must be 1-255 ASCII printable characters",
+        );
+    }
+    let user_id = user_id.trim();
+    let user = match state.totp_repo().find(ctx.account_id, user_id).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled"),
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    };
+    if user.status == "disabled" {
+        return error_response(StatusCode::NOT_FOUND, "not_found", "user not enrolled");
+    }
+    let secret = match state.encryptor().decrypt(&user.secret) {
+        Ok(s) => s,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    };
+    let issuer = user.issuer.clone().unwrap_or_else(|| "Chorus".to_string());
+    let label = user.label.clone().unwrap_or_else(|| user.user_id.clone());
+    let otpauth = totp::build_otpauth_uri(&issuer, &label, &totp::base32_no_pad(&secret));
+    let png_data_uri = match totp::qr_png_data_uri(&otpauth) {
+        Ok(s) => s,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", &e.to_string()),
+    };
+    use base64::Engine;
+    let b64 = png_data_uri.strip_prefix("data:image/png;base64,").unwrap_or("");
+    let png_bytes = base64::engine::general_purpose::STANDARD.decode(b64).unwrap_or_default();
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "image/png")],
+        png_bytes,
+    )
+        .into_response()
+}
+
 // ---- internal helpers ----
 
 fn unix_now() -> u64 {

--- a/services/chorus-server/src/totp.rs
+++ b/services/chorus-server/src/totp.rs
@@ -81,6 +81,66 @@ pub fn hash_user_id(user_id: &str) -> String {
     hex::encode(Sha256::digest(user_id.as_bytes()))
 }
 
+// ---- Backup codes ----
+
+/// Generate `BACKUP_CODE_COUNT` plaintext codes of format `[a-z0-9]{4}-[a-z0-9]{5}`.
+pub fn generate_backup_codes() -> Vec<String> {
+    use rand::Rng;
+    let mut rng = rand::rngs::OsRng;
+    const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let mut codes = Vec::with_capacity(BACKUP_CODE_COUNT);
+    for _ in 0..BACKUP_CODE_COUNT {
+        let mut s = String::with_capacity(10);
+        for i in 0..9 {
+            if i == 4 {
+                s.push('-');
+            }
+            let idx = rng.gen_range(0..CHARSET.len());
+            s.push(CHARSET[idx] as char);
+        }
+        codes.push(s);
+    }
+    codes
+}
+
+/// SHA-256 of plaintext backup code.
+pub fn hash_backup_code(code: &str) -> Vec<u8> {
+    Sha256::digest(code.as_bytes()).to_vec()
+}
+
+/// True if `s` looks like a backup code (`xxxx-xxxxx`), so the verify path
+/// can skip TOTP computation and consult the backup-codes table.
+pub fn is_backup_code_format(s: &str) -> bool {
+    s.len() == 10
+        && s.chars().nth(4) == Some('-')
+        && s.chars()
+            .enumerate()
+            .all(|(i, c)| i == 4 || (c.is_ascii_lowercase() || c.is_ascii_digit()))
+}
+
+// ---- QR code generation ----
+
+/// Render the otpauth URI as a 256×256 PNG and return as `data:image/png;base64,...`.
+pub fn qr_png_data_uri(otpauth_uri: &str) -> anyhow::Result<String> {
+    use base64::Engine;
+    use fast_qr::convert::image::ImageBuilder;
+    use fast_qr::convert::Builder;
+    use fast_qr::convert::Shape;
+    use fast_qr::qr::QRBuilder;
+
+    let qr = QRBuilder::new(otpauth_uri)
+        .build()
+        .map_err(|e| anyhow::anyhow!("QR build failed: {e:?}"))?;
+    let png = ImageBuilder::default()
+        .shape(Shape::Square)
+        .fit_width(256)
+        .to_pixmap(&qr)
+        .encode_png()
+        .map_err(|e| anyhow::anyhow!("PNG encode failed: {e}"))?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&png);
+    Ok(format!("data:image/png;base64,{b64}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,5 +243,86 @@ mod tests {
         let h = hash_user_id("alice@app.com");
         assert_eq!(h.len(), 64);
         assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn generate_backup_codes_returns_10() {
+        let codes = generate_backup_codes();
+        assert_eq!(codes.len(), BACKUP_CODE_COUNT);
+    }
+
+    #[test]
+    fn generate_backup_codes_match_format() {
+        let codes = generate_backup_codes();
+        for c in codes {
+            assert!(is_backup_code_format(&c), "bad format: {c:?}");
+        }
+    }
+
+    #[test]
+    fn generate_backup_codes_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..100 {
+            for c in generate_backup_codes() {
+                assert!(seen.insert(c.clone()), "duplicate code: {c}");
+            }
+        }
+    }
+
+    #[test]
+    fn is_backup_code_format_true_positive() {
+        assert!(is_backup_code_format("a3f8-9d2cx"));
+        assert!(is_backup_code_format("0000-00000"));
+    }
+
+    #[test]
+    fn is_backup_code_format_rejects_totp() {
+        assert!(!is_backup_code_format("483921"));
+    }
+
+    #[test]
+    fn is_backup_code_format_rejects_wrong_length() {
+        assert!(!is_backup_code_format("a3f8-9d2c"));   // 9 chars
+        assert!(!is_backup_code_format("a3f8-9d2cxx")); // 11 chars
+    }
+
+    #[test]
+    fn is_backup_code_format_rejects_uppercase() {
+        assert!(!is_backup_code_format("A3F8-9D2CX"));
+    }
+
+    #[test]
+    fn is_backup_code_format_rejects_missing_hyphen() {
+        assert!(!is_backup_code_format("a3f8x9d2cx"));
+    }
+
+    #[test]
+    fn hash_backup_code_is_32_bytes() {
+        assert_eq!(hash_backup_code("a3f8-9d2cx").len(), 32);
+    }
+
+    #[test]
+    fn hash_backup_code_is_deterministic() {
+        assert_eq!(hash_backup_code("a3f8-9d2cx"), hash_backup_code("a3f8-9d2cx"));
+    }
+
+    #[test]
+    fn qr_png_data_uri_returns_data_uri_prefix() {
+        let uri = "otpauth://totp/Acme:alice?secret=JBSWY3DPEHPK3PXP";
+        let result = qr_png_data_uri(uri).unwrap();
+        assert!(result.starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn qr_png_data_uri_is_valid_png() {
+        use base64::Engine;
+        let uri = "otpauth://totp/Acme:alice?secret=JBSWY3DPEHPK3PXP";
+        let data_uri = qr_png_data_uri(uri).unwrap();
+        let b64 = data_uri.strip_prefix("data:image/png;base64,").unwrap();
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .unwrap();
+        // PNG magic: 89 50 4E 47 0D 0A 1A 0A
+        assert_eq!(&bytes[..8], &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
     }
 }

--- a/services/chorus-server/src/totp.rs
+++ b/services/chorus-server/src/totp.rs
@@ -280,6 +280,16 @@ pub fn is_valid_user_id(s: &str) -> bool {
         && t.chars().all(|c| c.is_ascii_graphic() || c == ' ')
 }
 
+pub mod metrics_keys {
+    pub const ENROLLMENTS_TOTAL:    &str = "chorus_totp_enrollments_total";
+    pub const ACTIVATIONS_TOTAL:    &str = "chorus_totp_activations_total";
+    pub const VERIFIES_TOTAL:       &str = "chorus_totp_verifies_total";
+    pub const DISENROLLMENTS_TOTAL: &str = "chorus_totp_disenrollments_total";
+    pub const BACKUP_REMAINING:     &str = "chorus_totp_backup_codes_remaining";
+    pub const ENROLL_DURATION:      &str = "chorus_totp_enroll_duration_seconds";
+    pub const VERIFY_DURATION:      &str = "chorus_totp_verify_duration_seconds";
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/services/chorus-server/src/totp.rs
+++ b/services/chorus-server/src/totp.rs
@@ -34,12 +34,7 @@ pub fn generate_secret() -> [u8; SECRET_BYTES] {
 /// Always SHA1, 6 digits, 30 s step.
 pub fn compute_totp(secret: &[u8], time_seconds: u64) -> String {
     use totp_lite::{totp_custom, Sha1};
-    totp_custom::<Sha1>(
-        TOTP_PERIOD_SECS,
-        TOTP_DIGITS,
-        secret,
-        time_seconds,
-    )
+    totp_custom::<Sha1>(TOTP_PERIOD_SECS, TOTP_DIGITS, secret, time_seconds)
 }
 
 /// Verify `code` against the secret at the current step ± `TOTP_WINDOW`.
@@ -275,19 +270,17 @@ pub async fn check_rate_limits(
 /// Validate a user_id per spec (1-255 ASCII printable chars, trim).
 pub fn is_valid_user_id(s: &str) -> bool {
     let t = s.trim();
-    !t.is_empty()
-        && t.len() <= 255
-        && t.chars().all(|c| c.is_ascii_graphic() || c == ' ')
+    !t.is_empty() && t.len() <= 255 && t.chars().all(|c| c.is_ascii_graphic() || c == ' ')
 }
 
 pub mod metrics_keys {
-    pub const ENROLLMENTS_TOTAL:    &str = "chorus_totp_enrollments_total";
-    pub const ACTIVATIONS_TOTAL:    &str = "chorus_totp_activations_total";
-    pub const VERIFIES_TOTAL:       &str = "chorus_totp_verifies_total";
+    pub const ENROLLMENTS_TOTAL: &str = "chorus_totp_enrollments_total";
+    pub const ACTIVATIONS_TOTAL: &str = "chorus_totp_activations_total";
+    pub const VERIFIES_TOTAL: &str = "chorus_totp_verifies_total";
     pub const DISENROLLMENTS_TOTAL: &str = "chorus_totp_disenrollments_total";
-    pub const BACKUP_REMAINING:     &str = "chorus_totp_backup_codes_remaining";
-    pub const ENROLL_DURATION:      &str = "chorus_totp_enroll_duration_seconds";
-    pub const VERIFY_DURATION:      &str = "chorus_totp_verify_duration_seconds";
+    pub const BACKUP_REMAINING: &str = "chorus_totp_backup_codes_remaining";
+    pub const ENROLL_DURATION: &str = "chorus_totp_enroll_duration_seconds";
+    pub const VERIFY_DURATION: &str = "chorus_totp_verify_duration_seconds";
 }
 
 #[cfg(test)]
@@ -431,7 +424,7 @@ mod tests {
 
     #[test]
     fn is_backup_code_format_rejects_wrong_length() {
-        assert!(!is_backup_code_format("a3f8-9d2c"));   // 9 chars
+        assert!(!is_backup_code_format("a3f8-9d2c")); // 9 chars
         assert!(!is_backup_code_format("a3f8-9d2cxx")); // 11 chars
     }
 
@@ -452,7 +445,10 @@ mod tests {
 
     #[test]
     fn hash_backup_code_is_deterministic() {
-        assert_eq!(hash_backup_code("a3f8-9d2cx"), hash_backup_code("a3f8-9d2cx"));
+        assert_eq!(
+            hash_backup_code("a3f8-9d2cx"),
+            hash_backup_code("a3f8-9d2cx")
+        );
     }
 
     #[test]
@@ -472,7 +468,10 @@ mod tests {
             .decode(b64)
             .unwrap();
         // PNG magic: 89 50 4E 47 0D 0A 1A 0A
-        assert_eq!(&bytes[..8], &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+        assert_eq!(
+            &bytes[..8],
+            &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+        );
     }
 
     #[test]

--- a/services/chorus-server/src/totp.rs
+++ b/services/chorus-server/src/totp.rs
@@ -237,12 +237,12 @@ pub async fn check_rate_limits(
     let window_user_ms: u64 = 60 * 1000;
     let window_acct_ms: u64 = 60 * 1000;
 
-    let mut conn = redis
-        .get_multiplexed_tokio_connection()
-        .await
-        .map_err(|e| TotpError::Internal(anyhow::anyhow!(e)))?;
+    let mut conn = match redis.get_multiplexed_tokio_connection().await {
+        Ok(c) => c,
+        Err(_) => return Ok(()), // fail open — Redis unavailable, skip rate limiting
+    };
 
-    let result: (String, i64) = redis::Script::new(RATE_LIMIT_LUA)
+    let result: (String, i64) = match redis::Script::new(RATE_LIMIT_LUA)
         .key(&key_user)
         .key(&key_acct)
         .arg(now_ms)
@@ -253,7 +253,10 @@ pub async fn check_rate_limits(
         .arg(member)
         .invoke_async(&mut conn)
         .await
-        .map_err(|e| TotpError::Internal(anyhow::anyhow!(e)))?;
+    {
+        Ok(r) => r,
+        Err(_) => return Ok(()), // fail open — script error, skip rate limiting
+    };
 
     match result.0.as_str() {
         "ok" => Ok(()),

--- a/services/chorus-server/src/totp.rs
+++ b/services/chorus-server/src/totp.rs
@@ -141,6 +141,142 @@ pub fn qr_png_data_uri(otpauth_uri: &str) -> anyhow::Result<String> {
     Ok(format!("data:image/png;base64,{b64}"))
 }
 
+// ---- Errors + rate limit ----
+
+use uuid::Uuid;
+
+/// Reasons a TOTP operation may fail with a non-handler-specific error.
+#[derive(Debug)]
+pub enum TotpError {
+    InvalidUserId,
+    AlreadyEnrolled,
+    NotFound,
+    NotPending,
+    NotActive,
+    IncorrectCode,
+    RateLimitedUser { retry_after_sec: u64 },
+    RateLimitedAccount { retry_after_sec: u64 },
+    Db(crate::db::DbError),
+    Internal(anyhow::Error),
+}
+
+/// Which rate-limit pool to consult.
+#[derive(Debug, Clone, Copy)]
+pub enum RateLimitKind {
+    Verify,
+    Activate,
+    Enroll, // shared by /enroll and /backup-codes/regenerate
+}
+
+impl RateLimitKind {
+    fn user_key_prefix(self) -> &'static str {
+        match self {
+            RateLimitKind::Verify => "totp:rl:verify",
+            RateLimitKind::Activate => "totp:rl:activate",
+            RateLimitKind::Enroll => "totp:rl:enroll",
+        }
+    }
+
+    fn user_limit(self) -> u32 {
+        match self {
+            RateLimitKind::Verify => RATE_LIMIT_VERIFY_PER_USER_MIN,
+            RateLimitKind::Activate => RATE_LIMIT_ACTIVATE_PER_USER_MIN,
+            RateLimitKind::Enroll => RATE_LIMIT_ENROLL_PER_USER_MIN,
+        }
+    }
+}
+
+const RATE_LIMIT_LUA: &str = r#"
+local key_user    = KEYS[1]
+local key_acct    = KEYS[2]
+local now_ms      = tonumber(ARGV[1])
+local window_user = tonumber(ARGV[2])
+local limit_user  = tonumber(ARGV[3])
+local window_acct = tonumber(ARGV[4])
+local limit_acct  = tonumber(ARGV[5])
+local member      = ARGV[6]
+
+redis.call('ZREMRANGEBYSCORE', key_user, 0, now_ms - window_user)
+local count_user = redis.call('ZCARD', key_user)
+if count_user >= limit_user then
+    local oldest = redis.call('ZRANGE', key_user, 0, 0, 'WITHSCORES')
+    return {'user', tonumber(oldest[2]) + window_user - now_ms}
+end
+
+redis.call('ZREMRANGEBYSCORE', key_acct, 0, now_ms - window_acct)
+local count_acct = redis.call('ZCARD', key_acct)
+if count_acct >= limit_acct then
+    local oldest = redis.call('ZRANGE', key_acct, 0, 0, 'WITHSCORES')
+    return {'acct', tonumber(oldest[2]) + window_acct - now_ms}
+end
+
+redis.call('ZADD', key_user, now_ms, member)
+redis.call('ZADD', key_acct, now_ms, member)
+redis.call('EXPIRE', key_user, math.floor(window_user / 1000))
+redis.call('EXPIRE', key_acct, math.floor(window_acct / 1000))
+return {'ok', 0}
+"#;
+
+/// Sliding-window rate limit over per-user and per-account ZSETs.
+pub async fn check_rate_limits(
+    redis: &redis::Client,
+    account_id: Uuid,
+    user_id_hash: &str,
+    kind: RateLimitKind,
+) -> Result<(), TotpError> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| TotpError::Internal(anyhow::anyhow!("clock: {e}")))?
+        .as_millis() as u64;
+
+    let key_user = format!("{}:{}:{}", kind.user_key_prefix(), account_id, user_id_hash);
+    let key_acct = format!("totp:rl:acct:{account_id}");
+    let member = format!("{now_ms}:{}", Uuid::new_v4());
+
+    let window_user_ms: u64 = 60 * 1000;
+    let window_acct_ms: u64 = 60 * 1000;
+
+    let mut conn = redis
+        .get_multiplexed_tokio_connection()
+        .await
+        .map_err(|e| TotpError::Internal(anyhow::anyhow!(e)))?;
+
+    let result: (String, i64) = redis::Script::new(RATE_LIMIT_LUA)
+        .key(&key_user)
+        .key(&key_acct)
+        .arg(now_ms)
+        .arg(window_user_ms)
+        .arg(kind.user_limit())
+        .arg(window_acct_ms)
+        .arg(RATE_LIMIT_PER_ACCT_MIN)
+        .arg(member)
+        .invoke_async(&mut conn)
+        .await
+        .map_err(|e| TotpError::Internal(anyhow::anyhow!(e)))?;
+
+    match result.0.as_str() {
+        "ok" => Ok(()),
+        "user" => Err(TotpError::RateLimitedUser {
+            retry_after_sec: (result.1.max(0) as u64).div_ceil(1000),
+        }),
+        "acct" => Err(TotpError::RateLimitedAccount {
+            retry_after_sec: (result.1.max(0) as u64).div_ceil(1000),
+        }),
+        other => Err(TotpError::Internal(anyhow::anyhow!(
+            "unknown rate-limit outcome: {other}"
+        ))),
+    }
+}
+
+/// Validate a user_id per spec (1-255 ASCII printable chars, trim).
+pub fn is_valid_user_id(s: &str) -> bool {
+    let t = s.trim();
+    !t.is_empty()
+        && t.len() <= 255
+        && t.chars().all(|c| c.is_ascii_graphic() || c == ' ')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -324,5 +460,22 @@ mod tests {
             .unwrap();
         // PNG magic: 89 50 4E 47 0D 0A 1A 0A
         assert_eq!(&bytes[..8], &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+    }
+
+    #[test]
+    fn is_valid_user_id_accepts_typical() {
+        assert!(is_valid_user_id("alice"));
+        assert!(is_valid_user_id("alice@app.com"));
+        assert!(is_valid_user_id("550e8400-e29b-41d4-a716-446655440000"));
+        assert!(is_valid_user_id(&"a".repeat(255)));
+    }
+
+    #[test]
+    fn is_valid_user_id_rejects_bad() {
+        assert!(!is_valid_user_id(""));
+        assert!(!is_valid_user_id("   "));
+        assert!(!is_valid_user_id(&"a".repeat(256)));
+        assert!(!is_valid_user_id("user\nname"));
+        assert!(!is_valid_user_id("คีย์"));
     }
 }

--- a/services/chorus-server/src/totp.rs
+++ b/services/chorus-server/src/totp.rs
@@ -1,0 +1,187 @@
+//! TOTP orchestration: constants, code computation, QR generation, backup codes,
+//! rate-limit wrapper.
+//!
+//! See `docs/superpowers/specs/2026-05-19-totp-design.md`.
+
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+// ---- Constants (RFC 6238 defaults, locked in MVP) ----
+
+pub const TOTP_DIGITS: u32 = 6;
+pub const TOTP_PERIOD_SECS: u64 = 30;
+pub const TOTP_ALGORITHM: &str = "SHA1";
+pub const TOTP_WINDOW: i64 = 1; // ±1 step tolerance
+pub const SECRET_BYTES: usize = 20; // RFC 4226 recommended (160 bits)
+pub const BACKUP_CODE_COUNT: usize = 10;
+pub const LOW_BACKUP_THRESHOLD: i64 = 3;
+
+pub const RATE_LIMIT_VERIFY_PER_USER_MIN: u32 = 5;
+pub const RATE_LIMIT_ACTIVATE_PER_USER_MIN: u32 = 10;
+pub const RATE_LIMIT_ENROLL_PER_USER_MIN: u32 = 10;
+pub const RATE_LIMIT_PER_ACCT_MIN: u32 = 100;
+
+// ---- Secret + code generation ----
+
+/// Generate a new 20-byte (160-bit) TOTP secret using OsRng.
+pub fn generate_secret() -> [u8; SECRET_BYTES] {
+    let mut bytes = [0u8; SECRET_BYTES];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    bytes
+}
+
+/// Compute the TOTP code for `secret` at the given unix time (seconds).
+/// Always SHA1, 6 digits, 30 s step.
+pub fn compute_totp(secret: &[u8], time_seconds: u64) -> String {
+    use totp_lite::{totp_custom, Sha1};
+    totp_custom::<Sha1>(
+        TOTP_PERIOD_SECS,
+        TOTP_DIGITS,
+        secret,
+        time_seconds,
+    )
+}
+
+/// Verify `code` against the secret at the current step ± `TOTP_WINDOW`.
+pub fn verify_totp_with_window(secret: &[u8], now_seconds: u64, code: &str) -> bool {
+    let step = now_seconds / TOTP_PERIOD_SECS;
+    for offset in -TOTP_WINDOW..=TOTP_WINDOW {
+        let candidate_step = step as i64 + offset;
+        if candidate_step < 0 {
+            continue;
+        }
+        let candidate_time = (candidate_step as u64) * TOTP_PERIOD_SECS;
+        if compute_totp(secret, candidate_time) == code {
+            return true;
+        }
+    }
+    false
+}
+
+// ---- otpauth URI ----
+
+/// Encode bytes as RFC 4648 base32 with NO padding (TOTP convention).
+pub fn base32_no_pad(bytes: &[u8]) -> String {
+    base32::encode(base32::Alphabet::Rfc4648 { padding: false }, bytes)
+}
+
+/// Build the `otpauth://totp/...` URI per RFC 6238.
+/// `issuer` and `label` are URL-encoded; `secret_base32` is the raw base32 string.
+pub fn build_otpauth_uri(issuer: &str, label: &str, secret_base32: &str) -> String {
+    let issuer_enc = urlencoding::encode(issuer);
+    let label_enc = urlencoding::encode(label);
+    let secret_enc = urlencoding::encode(secret_base32);
+    format!(
+        "otpauth://totp/{issuer_enc}:{label_enc}?secret={secret_enc}&issuer={issuer_enc}&algorithm=SHA1&digits=6&period=30"
+    )
+}
+
+/// SHA-256 hash for use as recipient-style identifier (e.g. user_id in rate-limit keys).
+pub fn hash_user_id(user_id: &str) -> String {
+    hex::encode(Sha256::digest(user_id.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_secret_is_20_bytes() {
+        let s = generate_secret();
+        assert_eq!(s.len(), SECRET_BYTES);
+    }
+
+    #[test]
+    fn generate_secret_uses_full_entropy() {
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..100 {
+            let s = generate_secret();
+            assert!(seen.insert(s), "duplicate secret in 100 generations");
+        }
+    }
+
+    /// RFC 6238 Appendix B test vector (SHA-1).
+    /// Secret = ASCII "12345678901234567890".
+    #[test]
+    fn compute_totp_rfc6238_t1_59() {
+        let secret = b"12345678901234567890";
+        assert_eq!(compute_totp(secret, 59), "287082");
+    }
+
+    #[test]
+    fn compute_totp_rfc6238_t2_1111111109() {
+        let secret = b"12345678901234567890";
+        assert_eq!(compute_totp(secret, 1_111_111_109), "081804");
+    }
+
+    #[test]
+    fn compute_totp_rfc6238_t3_1234567890() {
+        let secret = b"12345678901234567890";
+        // RFC 6238 Appendix B gives 8-digit "89005924" for SHA1; 6-digit is 89005924 % 10^6 = 005924.
+        assert_eq!(compute_totp(secret, 1_234_567_890), "005924");
+    }
+
+    #[test]
+    fn verify_totp_with_window_accepts_current_step() {
+        let secret = b"12345678901234567890";
+        assert!(verify_totp_with_window(secret, 59, "287082"));
+    }
+
+    #[test]
+    fn verify_totp_with_window_accepts_previous_step() {
+        let secret = b"12345678901234567890";
+        // At t=89 (step=2), the previous step (step=1, t∈[30,59]) produced "287082".
+        assert!(verify_totp_with_window(secret, 89, "287082"));
+    }
+
+    #[test]
+    fn verify_totp_with_window_accepts_next_step() {
+        let secret = b"12345678901234567890";
+        // At t=29 (step=0), the next step (step=1, t∈[30,59]) produces "287082".
+        assert!(verify_totp_with_window(secret, 29, "287082"));
+    }
+
+    #[test]
+    fn verify_totp_with_window_rejects_outside_window() {
+        let secret = b"12345678901234567890";
+        // At t=120 (step=4), the code from step=1 (t=59) is ±3 steps away.
+        assert!(!verify_totp_with_window(secret, 120, "287082"));
+    }
+
+    #[test]
+    fn verify_totp_with_window_rejects_wrong_code() {
+        let secret = b"12345678901234567890";
+        assert!(!verify_totp_with_window(secret, 59, "000000"));
+    }
+
+    #[test]
+    fn base32_no_pad_known_vector() {
+        // RFC 4648 §10: "foobar" → "MZXW6YTBOI" (no padding).
+        assert_eq!(base32_no_pad(b"foobar"), "MZXW6YTBOI");
+    }
+
+    #[test]
+    fn otpauth_uri_format() {
+        let uri = build_otpauth_uri("Acme", "alice", "JBSWY3DPEHPK3PXP");
+        assert!(uri.starts_with("otpauth://totp/Acme:alice?"));
+        assert!(uri.contains("secret=JBSWY3DPEHPK3PXP"));
+        assert!(uri.contains("issuer=Acme"));
+        assert!(uri.contains("algorithm=SHA1"));
+        assert!(uri.contains("digits=6"));
+        assert!(uri.contains("period=30"));
+    }
+
+    #[test]
+    fn otpauth_uri_escapes_special_chars() {
+        let uri = build_otpauth_uri("Acme Inc", "alice@app.com", "JBSWY3DPEHPK3PXP");
+        assert!(uri.contains("Acme%20Inc"));
+        assert!(uri.contains("alice%40app.com"));
+    }
+
+    #[test]
+    fn hash_user_id_is_64_hex_chars() {
+        let h = hash_user_id("alice@app.com");
+        assert_eq!(h.len(), 64);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/services/chorus-server/tests/api_test.rs
+++ b/services/chorus-server/tests/api_test.rs
@@ -114,7 +114,9 @@ impl TotpRepository for NullTotpRepo {
         _new_user: &NewTotpUser,
         _hashes: &[Vec<u8>],
     ) -> Result<TotpUser, DbError> {
-        Err(DbError::Internal(anyhow::anyhow!("NullTotpRepo::enroll not implemented")))
+        Err(DbError::Internal(anyhow::anyhow!(
+            "NullTotpRepo::enroll not implemented"
+        )))
     }
     async fn find(&self, _account_id: Uuid, _user_id: &str) -> Result<Option<TotpUser>, DbError> {
         Ok(None)
@@ -122,11 +124,7 @@ impl TotpRepository for NullTotpRepo {
     async fn activate(&self, _account_id: Uuid, _user_id: &str) -> Result<(), DbError> {
         Err(DbError::NotFound)
     }
-    async fn touch_last_verified(
-        &self,
-        _account_id: Uuid,
-        _user_id: &str,
-    ) -> Result<(), DbError> {
+    async fn touch_last_verified(&self, _account_id: Uuid, _user_id: &str) -> Result<(), DbError> {
         Ok(())
     }
     async fn disenroll(&self, _account_id: Uuid, _user_id: &str) -> Result<bool, DbError> {
@@ -3089,9 +3087,13 @@ async fn legacy_otp_send_still_works() {
 
 // ----- B2 TOTP tests -----
 
+/// One row of the in-memory backup-codes table:
+/// (account_id, user_id, code_hash, used_at).
+type MemBackupCodeRow = (Uuid, String, Vec<u8>, Option<chrono::DateTime<Utc>>);
+
 struct MemTotpRepo {
     users: tokio::sync::Mutex<Vec<TotpUser>>,
-    codes: tokio::sync::Mutex<Vec<(Uuid, String, Vec<u8>, Option<chrono::DateTime<Utc>>)>>,
+    codes: tokio::sync::Mutex<Vec<MemBackupCodeRow>>,
 }
 
 impl MemTotpRepo {
@@ -3111,7 +3113,10 @@ impl TotpRepository for MemTotpRepo {
         hashes: &[Vec<u8>],
     ) -> Result<TotpUser, DbError> {
         let mut users = self.users.lock().await;
-        if users.iter().any(|u| u.account_id == new_user.account_id && u.user_id == new_user.user_id) {
+        if users
+            .iter()
+            .any(|u| u.account_id == new_user.account_id && u.user_id == new_user.user_id)
+        {
             return Err(DbError::Internal(anyhow::anyhow!("duplicate")));
         }
         let now = Utc::now();
@@ -3133,7 +3138,12 @@ impl TotpRepository for MemTotpRepo {
         users.push(u.clone());
         let mut codes = self.codes.lock().await;
         for h in hashes {
-            codes.push((new_user.account_id, new_user.user_id.clone(), h.clone(), None));
+            codes.push((
+                new_user.account_id,
+                new_user.user_id.clone(),
+                h.clone(),
+                None,
+            ));
         }
         Ok(u)
     }
@@ -3161,11 +3171,7 @@ impl TotpRepository for MemTotpRepo {
         Err(DbError::NotFound)
     }
 
-    async fn touch_last_verified(
-        &self,
-        account_id: Uuid,
-        user_id: &str,
-    ) -> Result<(), DbError> {
+    async fn touch_last_verified(&self, account_id: Uuid, user_id: &str) -> Result<(), DbError> {
         let mut users = self.users.lock().await;
         if let Some(u) = users
             .iter_mut()
@@ -3238,13 +3244,23 @@ fn fixture_with_totp() -> (Arc<AppState>, Arc<MemTotpRepo>) {
     let key_id = Uuid::new_v4();
     let account_repo = Arc::new(MockAccountRepo {
         account: Account {
-            id: account_id, name: "Test".into(), owner_email: "t@t".into(),
-            is_active: true, created_at: Utc::now(), updated_at: Utc::now(),
+            id: account_id,
+            name: "Test".into(),
+            owner_email: "t@t".into(),
+            is_active: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
         },
         api_key: ApiKey {
-            id: key_id, account_id, name: "k".into(), key_prefix: "ch_test_ab...".into(),
-            environment: "test".into(), last_used_at: None, expires_at: None,
-            is_revoked: false, created_at: Utc::now(),
+            id: key_id,
+            account_id,
+            name: "k".into(),
+            key_prefix: "ch_test_ab...".into(),
+            environment: "test".into(),
+            last_used_at: None,
+            expires_at: None,
+            is_revoked: false,
+            created_at: Utc::now(),
         },
         key_hash,
     });
@@ -3261,9 +3277,18 @@ fn fixture_with_totp() -> (Arc<AppState>, Arc<MemTotpRepo>) {
     let redis = redis::Client::open("redis://127.0.0.1:6379").unwrap();
     let config = Arc::new(Config::from_env());
     let state = Arc::new(AppState::with_repos(
-        redis, config, account_repo, messages, api_key_repo,
-        provider_config_repo, webhook_repo, suppressions,
-        idempotency_repo, verification_repo, totp_dyn, encryptor,
+        redis,
+        config,
+        account_repo,
+        messages,
+        api_key_repo,
+        provider_config_repo,
+        webhook_repo,
+        suppressions,
+        idempotency_repo,
+        verification_repo,
+        totp_dyn,
+        encryptor,
     ));
     (state, totp_repo)
 }
@@ -3290,8 +3315,14 @@ async fn enroll_returns_qr_and_pending_status() {
     let v = response_body(resp).await;
     assert_eq!(v["user_id"], "alice@app.com");
     assert_eq!(v["status"], "pending");
-    assert!(v["otpauth_uri"].as_str().unwrap().starts_with("otpauth://totp/"));
-    assert!(v["qr_code_png"].as_str().unwrap().starts_with("data:image/png;base64,"));
+    assert!(v["otpauth_uri"]
+        .as_str()
+        .unwrap()
+        .starts_with("otpauth://totp/"));
+    assert!(v["qr_code_png"]
+        .as_str()
+        .unwrap()
+        .starts_with("data:image/png;base64,"));
     assert_eq!(v["backup_codes"].as_array().unwrap().len(), 10);
     assert_eq!(v["cost_micro"], 0);
 }
@@ -3303,7 +3334,8 @@ async fn enroll_returns_400_when_user_id_empty() {
     let resp = app
         .oneshot(
             Request::builder()
-                .method("POST").uri("/v1/totp/enroll")
+                .method("POST")
+                .uri("/v1/totp/enroll")
                 .header("authorization", format!("Bearer {TEST_API_KEY}"))
                 .header("content-type", "application/json")
                 .body(axum::body::Body::from(r#"{"user_id":""}"#))
@@ -3312,7 +3344,10 @@ async fn enroll_returns_400_when_user_id_empty() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    assert_eq!(response_body(resp).await["error"]["code"], "invalid_user_id");
+    assert_eq!(
+        response_body(resp).await["error"]["code"],
+        "invalid_user_id"
+    );
 }
 
 #[tokio::test]
@@ -3324,7 +3359,8 @@ async fn enroll_returns_400_when_user_id_too_long() {
     let resp = app
         .oneshot(
             Request::builder()
-                .method("POST").uri("/v1/totp/enroll")
+                .method("POST")
+                .uri("/v1/totp/enroll")
                 .header("authorization", format!("Bearer {TEST_API_KEY}"))
                 .header("content-type", "application/json")
                 .body(axum::body::Body::from(body))
@@ -3341,21 +3377,37 @@ async fn enroll_returns_409_when_user_already_enrolled() {
     let (state, _repo) = fixture_with_totp();
     let app = create_router(state);
     let body = serde_json::json!({"user_id":"alice"}).to_string();
-    let _ = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body.clone())).unwrap()
-    ).await.unwrap();
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
 
-    let resp = app.oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body)).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::CONFLICT);
-    assert_eq!(response_body(resp).await["error"]["code"], "already_enrolled");
+    assert_eq!(
+        response_body(resp).await["error"]["code"],
+        "already_enrolled"
+    );
 }
 
 #[tokio::test]
@@ -3366,23 +3418,36 @@ async fn enroll_idempotency_replay_is_identical() {
     let key = "enroll-key-1";
     let body = serde_json::json!({"user_id":"bob"}).to_string();
 
-    let resp1 = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("Idempotency-Key", key)
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body.clone())).unwrap()
-    ).await.unwrap();
+    let resp1 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("Idempotency-Key", key)
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp1.status(), StatusCode::CREATED);
     let bytes1 = resp1.into_body().collect().await.unwrap().to_bytes();
 
-    let resp2 = app.oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("Idempotency-Key", key)
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body)).unwrap()
-    ).await.unwrap();
+    let resp2 = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("Idempotency-Key", key)
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp2.status(), StatusCode::CREATED);
     let bytes2 = resp2.into_body().collect().await.unwrap().to_bytes();
     assert_eq!(bytes1, bytes2);
@@ -3395,12 +3460,16 @@ async fn activate_returns_404_when_unknown_user() {
     let body = serde_json::json!({"user_id":"ghost","code":"123456"}).to_string();
     let resp = app
         .oneshot(
-            Request::builder().method("POST").uri("/v1/totp/activate")
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/activate")
                 .header("authorization", format!("Bearer {TEST_API_KEY}"))
                 .header("content-type", "application/json")
-                .body(axum::body::Body::from(body)).unwrap(),
+                .body(axum::body::Body::from(body))
+                .unwrap(),
         )
-        .await.unwrap();
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
@@ -3410,25 +3479,45 @@ async fn disenroll_active_user_succeeds_and_second_call_returns_410() {
     let (state, _repo) = fixture_with_totp();
     let app = create_router(state);
     let body = serde_json::json!({"user_id":"alice"}).to_string();
-    let _ = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body)).unwrap()
-    ).await.unwrap();
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
 
-    let resp = app.clone().oneshot(
-        Request::builder().method("DELETE").uri("/v1/totp/alice")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .body(axum::body::Body::empty()).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/totp/alice")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let resp = app.oneshot(
-        Request::builder().method("DELETE").uri("/v1/totp/alice")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .body(axum::body::Body::empty()).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/totp/alice")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::GONE);
 }
 
@@ -3436,11 +3525,17 @@ async fn disenroll_active_user_succeeds_and_second_call_returns_410() {
 async fn status_for_unknown_user_returns_404() {
     let (state, _repo) = fixture_with_totp();
     let app = create_router(state);
-    let resp = app.oneshot(
-        Request::builder().method("GET").uri("/v1/totp/ghost")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .body(axum::body::Body::empty()).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/totp/ghost")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
@@ -3449,19 +3544,31 @@ async fn status_for_unknown_user_returns_404() {
 async fn status_for_pending_user_returns_metadata() {
     let (state, _repo) = fixture_with_totp();
     let app = create_router(state);
-    let _ = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#))
-            .unwrap()
-    ).await.unwrap();
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(r#"{"user_id":"alice"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
 
-    let resp = app.oneshot(
-        Request::builder().method("GET").uri("/v1/totp/alice")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .body(axum::body::Body::empty()).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/totp/alice")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let v = response_body(resp).await;
     assert_eq!(v["user_id"], "alice");
@@ -3476,12 +3583,18 @@ async fn verify_returns_404_when_unknown_user() {
     let app = create_router(state);
     // No enrollment exists → find returns None → 404
     let body = serde_json::json!({"user_id":"ghost","code":"483921"}).to_string();
-    let resp = app.oneshot(
-        Request::builder().method("POST").uri("/v1/totp/verify")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body)).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/verify")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
@@ -3490,12 +3603,19 @@ async fn verify_returns_404_when_unknown_user() {
 async fn verify_with_backup_code_consumes_one() {
     let (state, repo) = fixture_with_totp();
     let app = create_router(state);
-    let resp = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#)).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(r#"{"user_id":"alice"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     let v = response_body(resp).await;
     let backup0 = v["backup_codes"][0].as_str().unwrap().to_string();
 
@@ -3503,17 +3623,26 @@ async fn verify_with_backup_code_consumes_one() {
     {
         let mut users = repo.users.lock().await;
         for x in users.iter_mut() {
-            if x.user_id == "alice" { x.status = "active".into(); }
+            if x.user_id == "alice" {
+                x.status = "active".into();
+            }
         }
     }
 
     let body = serde_json::json!({"user_id":"alice","code":backup0}).to_string();
-    let resp = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/verify")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body.clone())).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/verify")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let v = response_body(resp).await;
     assert_eq!(v["verified"], true);
@@ -3521,12 +3650,18 @@ async fn verify_with_backup_code_consumes_one() {
     assert_eq!(v["cost_micro"], 0);
 
     // Replay same backup code → 422 incorrect_code
-    let resp = app.oneshot(
-        Request::builder().method("POST").uri("/v1/totp/verify")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body)).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/verify")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_eq!(response_body(resp).await["error"]["code"], "incorrect_code");
 }
@@ -3536,12 +3671,19 @@ async fn verify_with_backup_code_consumes_one() {
 async fn regenerate_returns_new_backup_codes_and_invalidates_old() {
     let (state, repo) = fixture_with_totp();
     let app = create_router(state);
-    let resp = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#)).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(r#"{"user_id":"alice"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     let v = response_body(resp).await;
     let old_first = v["backup_codes"][0].as_str().unwrap().to_string();
 
@@ -3549,16 +3691,25 @@ async fn regenerate_returns_new_backup_codes_and_invalidates_old() {
     {
         let mut users = repo.users.lock().await;
         for x in users.iter_mut() {
-            if x.user_id == "alice" { x.status = "active".into(); }
+            if x.user_id == "alice" {
+                x.status = "active".into();
+            }
         }
     }
 
-    let resp = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/backup-codes/regenerate")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#)).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/backup-codes/regenerate")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(r#"{"user_id":"alice"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let v = response_body(resp).await;
     let new_codes = v["backup_codes"].as_array().unwrap();
@@ -3567,12 +3718,18 @@ async fn regenerate_returns_new_backup_codes_and_invalidates_old() {
 
     // Old code now invalid → 422
     let body = serde_json::json!({"user_id":"alice","code":old_first}).to_string();
-    let resp = app.oneshot(
-        Request::builder().method("POST").uri("/v1/totp/verify")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(body)).unwrap()
-    ).await.unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/verify")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
 
@@ -3581,27 +3738,43 @@ async fn regenerate_returns_new_backup_codes_and_invalidates_old() {
 async fn rate_limit_per_user_blocks_after_5_verifies() {
     let (state, repo) = fixture_with_totp();
     let app = create_router(state);
-    let _ = app.clone().oneshot(
-        Request::builder().method("POST").uri("/v1/totp/enroll")
-            .header("authorization", format!("Bearer {TEST_API_KEY}"))
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#)).unwrap()
-    ).await.unwrap();
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(r#"{"user_id":"alice"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     {
         let mut users = repo.users.lock().await;
         for x in users.iter_mut() {
-            if x.user_id == "alice" { x.status = "active".into(); }
+            if x.user_id == "alice" {
+                x.status = "active".into();
+            }
         }
     }
     let body = serde_json::json!({"user_id":"alice","code":"000000"}).to_string();
     let mut codes_seen = vec![];
     for _ in 0..6 {
-        let resp = app.clone().oneshot(
-            Request::builder().method("POST").uri("/v1/totp/verify")
-                .header("authorization", format!("Bearer {TEST_API_KEY}"))
-                .header("content-type", "application/json")
-                .body(axum::body::Body::from(body.clone())).unwrap()
-        ).await.unwrap();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/totp/verify")
+                    .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(body.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         codes_seen.push(resp.status().as_u16());
     }
     // First 5: 422 incorrect_code; 6th: 429 rate_limited

--- a/services/chorus-server/tests/api_test.rs
+++ b/services/chorus-server/tests/api_test.rs
@@ -3478,3 +3478,127 @@ async fn verify_returns_404_when_unknown_user() {
     ).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+#[ignore = "requires Valkey/Redis on localhost:6379"]
+async fn verify_with_backup_code_consumes_one() {
+    let (state, repo) = fixture_with_totp();
+    let app = create_router(state);
+    let resp = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#)).unwrap()
+    ).await.unwrap();
+    let v = response_body(resp).await;
+    let backup0 = v["backup_codes"][0].as_str().unwrap().to_string();
+
+    // Move user to active status directly via the repo (skip /activate which requires TOTP code)
+    {
+        let mut users = repo.users.lock().await;
+        for x in users.iter_mut() {
+            if x.user_id == "alice" { x.status = "active".into(); }
+        }
+    }
+
+    let body = serde_json::json!({"user_id":"alice","code":backup0}).to_string();
+    let resp = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/verify")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body.clone())).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = response_body(resp).await;
+    assert_eq!(v["verified"], true);
+    assert_eq!(v["method"], "backup_code");
+    assert_eq!(v["cost_micro"], 0);
+
+    // Replay same backup code → 422 incorrect_code
+    let resp = app.oneshot(
+        Request::builder().method("POST").uri("/v1/totp/verify")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body)).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(response_body(resp).await["error"]["code"], "incorrect_code");
+}
+
+#[tokio::test]
+#[ignore = "requires Valkey/Redis on localhost:6379"]
+async fn regenerate_returns_new_backup_codes_and_invalidates_old() {
+    let (state, repo) = fixture_with_totp();
+    let app = create_router(state);
+    let resp = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#)).unwrap()
+    ).await.unwrap();
+    let v = response_body(resp).await;
+    let old_first = v["backup_codes"][0].as_str().unwrap().to_string();
+
+    // Make user active
+    {
+        let mut users = repo.users.lock().await;
+        for x in users.iter_mut() {
+            if x.user_id == "alice" { x.status = "active".into(); }
+        }
+    }
+
+    let resp = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/backup-codes/regenerate")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#)).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = response_body(resp).await;
+    let new_codes = v["backup_codes"].as_array().unwrap();
+    assert_eq!(new_codes.len(), 10);
+    assert!(!new_codes.iter().any(|c| c.as_str().unwrap() == old_first));
+
+    // Old code now invalid → 422
+    let body = serde_json::json!({"user_id":"alice","code":old_first}).to_string();
+    let resp = app.oneshot(
+        Request::builder().method("POST").uri("/v1/totp/verify")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body)).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+#[ignore = "requires Valkey/Redis on localhost:6379"]
+async fn rate_limit_per_user_blocks_after_5_verifies() {
+    let (state, repo) = fixture_with_totp();
+    let app = create_router(state);
+    let _ = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#)).unwrap()
+    ).await.unwrap();
+    {
+        let mut users = repo.users.lock().await;
+        for x in users.iter_mut() {
+            if x.user_id == "alice" { x.status = "active".into(); }
+        }
+    }
+    let body = serde_json::json!({"user_id":"alice","code":"000000"}).to_string();
+    let mut codes_seen = vec![];
+    for _ in 0..6 {
+        let resp = app.clone().oneshot(
+            Request::builder().method("POST").uri("/v1/totp/verify")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body.clone())).unwrap()
+        ).await.unwrap();
+        codes_seen.push(resp.status().as_u16());
+    }
+    // First 5: 422 incorrect_code; 6th: 429 rate_limited
+    assert_eq!(&codes_seen[..5], &[422, 422, 422, 422, 422]);
+    assert_eq!(codes_seen[5], 429);
+}

--- a/services/chorus-server/tests/api_test.rs
+++ b/services/chorus-server/tests/api_test.rs
@@ -11,12 +11,13 @@ use uuid::Uuid;
 // Re-use types from chorus-server
 use chorus_server::app::{create_router, AppState};
 use chorus_server::config::Config;
+use chorus_server::crypto::Encryptor;
 use chorus_server::db::{
     Account, AccountRepository, AddSuppressionResult, ApiKey, ApiKeyRepository, DbError,
     DeliveryEvent, IdempotencyOutcome, IdempotencyRepository, Message, MessageRepository,
-    NewMessage, NewProviderConfig, NewSuppression, NewVerification, NewWebhook, Pagination,
-    ProviderConfig, ProviderConfigRepository, Suppression, SuppressionRepository, Verification,
-    VerificationRepository, Webhook, WebhookRepository,
+    NewMessage, NewProviderConfig, NewSuppression, NewTotpUser, NewVerification, NewWebhook,
+    Pagination, ProviderConfig, ProviderConfigRepository, Suppression, SuppressionRepository,
+    TotpRepository, TotpUser, Verification, VerificationRepository, Webhook, WebhookRepository,
 };
 
 // ---------------------------------------------------------------------------
@@ -101,6 +102,73 @@ impl chorus_server::db::VerificationRepository for NullVerificationRepo {
     async fn expire_pending(&self, _limit: i64) -> Result<u64, DbError> {
         Ok(0)
     }
+}
+
+/// No-op TOTP repo for tests that don't exercise TOTP logic.
+struct NullTotpRepo;
+
+#[async_trait]
+impl TotpRepository for NullTotpRepo {
+    async fn enroll(
+        &self,
+        _new_user: &NewTotpUser,
+        _hashes: &[Vec<u8>],
+    ) -> Result<TotpUser, DbError> {
+        Err(DbError::Internal(anyhow::anyhow!("NullTotpRepo::enroll not implemented")))
+    }
+    async fn find(&self, _account_id: Uuid, _user_id: &str) -> Result<Option<TotpUser>, DbError> {
+        Ok(None)
+    }
+    async fn activate(&self, _account_id: Uuid, _user_id: &str) -> Result<(), DbError> {
+        Err(DbError::NotFound)
+    }
+    async fn touch_last_verified(
+        &self,
+        _account_id: Uuid,
+        _user_id: &str,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+    async fn disenroll(&self, _account_id: Uuid, _user_id: &str) -> Result<bool, DbError> {
+        Ok(false)
+    }
+    async fn consume_backup_code(
+        &self,
+        _account_id: Uuid,
+        _user_id: &str,
+        _hash: &[u8],
+    ) -> Result<bool, DbError> {
+        Ok(false)
+    }
+    async fn unused_backup_codes_count(
+        &self,
+        _account_id: Uuid,
+        _user_id: &str,
+    ) -> Result<i64, DbError> {
+        Ok(0)
+    }
+    async fn replace_backup_codes(
+        &self,
+        _account_id: Uuid,
+        _user_id: &str,
+        _hashes: &[Vec<u8>],
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+}
+
+/// Test helper: 32-byte zero-key Encryptor (NOT for production).
+fn null_encryptor() -> Arc<Encryptor> {
+    use base64::Engine;
+    let key_b64 = base64::engine::general_purpose::STANDARD.encode([0u8; 32]);
+    let prev = std::env::var("CHORUS_ENCRYPTION_KEY").ok();
+    std::env::set_var("CHORUS_ENCRYPTION_KEY", &key_b64);
+    let enc = Encryptor::from_env().expect("encryptor from null key");
+    match prev {
+        Some(v) => std::env::set_var("CHORUS_ENCRYPTION_KEY", v),
+        None => std::env::remove_var("CHORUS_ENCRYPTION_KEY"),
+    }
+    Arc::new(enc)
 }
 
 struct MockAccountRepo {
@@ -506,6 +574,8 @@ fn test_fixture() -> TestFixture {
 
     let idempotency_repo: Arc<dyn IdempotencyRepository> = Arc::new(NullIdempotencyRepo);
     let verification_repo: Arc<dyn VerificationRepository> = Arc::new(NullVerificationRepo);
+    let totp_repo: Arc<dyn TotpRepository> = Arc::new(NullTotpRepo);
+    let encryptor = null_encryptor();
 
     let state = Arc::new(AppState::with_repos(
         redis,
@@ -518,6 +588,8 @@ fn test_fixture() -> TestFixture {
         suppressions.clone(),
         idempotency_repo,
         verification_repo,
+        totp_repo,
+        encryptor,
     ));
 
     TestFixture {
@@ -1778,6 +1850,8 @@ fn fixture_with_mem_idempotency() -> (Arc<AppState>, Arc<MockMessageRepo>) {
     let webhook_repo = Arc::new(MockWebhookRepo);
     let idempotency_repo: Arc<dyn IdempotencyRepository> = Arc::new(MemIdempotencyRepo::new());
     let verification_repo: Arc<dyn VerificationRepository> = Arc::new(NullVerificationRepo);
+    let totp_repo: Arc<dyn TotpRepository> = Arc::new(NullTotpRepo);
+    let encryptor = null_encryptor();
 
     let redis = redis::Client::open("redis://127.0.0.1:6379").unwrap();
     let config = Arc::new(Config::from_env());
@@ -1793,6 +1867,8 @@ fn fixture_with_mem_idempotency() -> (Arc<AppState>, Arc<MockMessageRepo>) {
         suppressions,
         idempotency_repo,
         verification_repo,
+        totp_repo,
+        encryptor,
     ));
 
     (state, messages)
@@ -2236,6 +2312,8 @@ fn fixture_two_api_keys() -> Arc<AppState> {
     let webhook_repo = Arc::new(MockWebhookRepo);
     let idempotency_repo: Arc<dyn IdempotencyRepository> = Arc::new(MemIdempotencyRepo::new());
     let verification_repo: Arc<dyn VerificationRepository> = Arc::new(NullVerificationRepo);
+    let totp_repo: Arc<dyn TotpRepository> = Arc::new(NullTotpRepo);
+    let encryptor = null_encryptor();
 
     let redis = redis::Client::open("redis://127.0.0.1:6379").unwrap();
     let config = Arc::new(Config::from_env());
@@ -2251,6 +2329,8 @@ fn fixture_two_api_keys() -> Arc<AppState> {
         suppressions,
         idempotency_repo,
         verification_repo,
+        totp_repo,
+        encryptor,
     ))
 }
 
@@ -2490,6 +2570,8 @@ fn fixture_with_verification() -> (Arc<AppState>, Arc<MemVerificationRepo>) {
     let idempotency_repo: Arc<dyn IdempotencyRepository> = Arc::new(MemIdempotencyRepo::new());
     let verification_repo: Arc<MemVerificationRepo> = Arc::new(MemVerificationRepo::new());
     let verification_dyn: Arc<dyn VerificationRepository> = verification_repo.clone();
+    let totp_repo: Arc<dyn TotpRepository> = Arc::new(NullTotpRepo);
+    let encryptor = null_encryptor();
     let redis = redis::Client::open("redis://127.0.0.1:6379").unwrap();
     let config = Arc::new(Config::from_env());
     let state = Arc::new(AppState::with_repos(
@@ -2503,6 +2585,8 @@ fn fixture_with_verification() -> (Arc<AppState>, Arc<MemVerificationRepo>) {
         suppressions,
         idempotency_repo,
         verification_dyn,
+        totp_repo,
+        encryptor,
     ));
     (state, verification_repo)
 }

--- a/services/chorus-server/tests/api_test.rs
+++ b/services/chorus-server/tests/api_test.rs
@@ -157,18 +157,24 @@ impl TotpRepository for NullTotpRepo {
     }
 }
 
-/// Test helper: 32-byte zero-key Encryptor (NOT for production).
+/// Test helper: returns a shared `Arc<Encryptor>` constructed once from a
+/// 32-byte fixed test key. NOT for production — for tests only.
+///
+/// We bypass `Encryptor::from_env` to avoid racing on the `CHORUS_ENCRYPTION_KEY`
+/// env var when tests run in parallel.
 fn null_encryptor() -> Arc<Encryptor> {
-    use base64::Engine;
-    let key_b64 = base64::engine::general_purpose::STANDARD.encode([0u8; 32]);
-    let prev = std::env::var("CHORUS_ENCRYPTION_KEY").ok();
-    std::env::set_var("CHORUS_ENCRYPTION_KEY", &key_b64);
-    let enc = Encryptor::from_env().expect("encryptor from null key");
-    match prev {
-        Some(v) => std::env::set_var("CHORUS_ENCRYPTION_KEY", v),
-        None => std::env::remove_var("CHORUS_ENCRYPTION_KEY"),
-    }
-    Arc::new(enc)
+    use std::sync::OnceLock;
+    static ENCRYPTOR: OnceLock<Arc<Encryptor>> = OnceLock::new();
+    ENCRYPTOR
+        .get_or_init(|| {
+            use base64::Engine;
+            let key_b64 = base64::engine::general_purpose::STANDARD.encode([0u8; 32]);
+            // Set the env var (safe here because this runs exactly once,
+            // before any other test thread reads it via this helper).
+            std::env::set_var("CHORUS_ENCRYPTION_KEY", &key_b64);
+            Arc::new(Encryptor::from_env().expect("encryptor from null key"))
+        })
+        .clone()
 }
 
 struct MockAccountRepo {

--- a/services/chorus-server/tests/api_test.rs
+++ b/services/chorus-server/tests/api_test.rs
@@ -3080,3 +3080,401 @@ async fn legacy_otp_send_still_works() {
     // Legacy route returns 422 due to suppression — works as before.
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
+
+// ----- B2 TOTP tests -----
+
+struct MemTotpRepo {
+    users: tokio::sync::Mutex<Vec<TotpUser>>,
+    codes: tokio::sync::Mutex<Vec<(Uuid, String, Vec<u8>, Option<chrono::DateTime<Utc>>)>>,
+}
+
+impl MemTotpRepo {
+    fn new() -> Self {
+        Self {
+            users: tokio::sync::Mutex::new(vec![]),
+            codes: tokio::sync::Mutex::new(vec![]),
+        }
+    }
+}
+
+#[async_trait]
+impl TotpRepository for MemTotpRepo {
+    async fn enroll(
+        &self,
+        new_user: &NewTotpUser,
+        hashes: &[Vec<u8>],
+    ) -> Result<TotpUser, DbError> {
+        let mut users = self.users.lock().await;
+        if users.iter().any(|u| u.account_id == new_user.account_id && u.user_id == new_user.user_id) {
+            return Err(DbError::Internal(anyhow::anyhow!("duplicate")));
+        }
+        let now = Utc::now();
+        let u = TotpUser {
+            account_id: new_user.account_id,
+            user_id: new_user.user_id.clone(),
+            secret: new_user.encrypted_secret.clone(),
+            status: "pending".into(),
+            algorithm: "SHA1".into(),
+            digits: 6,
+            period_secs: 30,
+            issuer: new_user.issuer.clone(),
+            label: new_user.label.clone(),
+            last_verified_at: None,
+            created_at: now,
+            activated_at: None,
+            updated_at: now,
+        };
+        users.push(u.clone());
+        let mut codes = self.codes.lock().await;
+        for h in hashes {
+            codes.push((new_user.account_id, new_user.user_id.clone(), h.clone(), None));
+        }
+        Ok(u)
+    }
+
+    async fn find(&self, account_id: Uuid, user_id: &str) -> Result<Option<TotpUser>, DbError> {
+        Ok(self
+            .users
+            .lock()
+            .await
+            .iter()
+            .find(|u| u.account_id == account_id && u.user_id == user_id)
+            .cloned())
+    }
+
+    async fn activate(&self, account_id: Uuid, user_id: &str) -> Result<(), DbError> {
+        let mut users = self.users.lock().await;
+        if let Some(u) = users
+            .iter_mut()
+            .find(|u| u.account_id == account_id && u.user_id == user_id && u.status == "pending")
+        {
+            u.status = "active".into();
+            u.activated_at = Some(Utc::now());
+            return Ok(());
+        }
+        Err(DbError::NotFound)
+    }
+
+    async fn touch_last_verified(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+    ) -> Result<(), DbError> {
+        let mut users = self.users.lock().await;
+        if let Some(u) = users
+            .iter_mut()
+            .find(|u| u.account_id == account_id && u.user_id == user_id && u.status == "active")
+        {
+            u.last_verified_at = Some(Utc::now());
+        }
+        Ok(())
+    }
+
+    async fn disenroll(&self, account_id: Uuid, user_id: &str) -> Result<bool, DbError> {
+        let mut users = self.users.lock().await;
+        if let Some(u) = users
+            .iter_mut()
+            .find(|u| u.account_id == account_id && u.user_id == user_id && u.status != "disabled")
+        {
+            u.status = "disabled".into();
+            u.secret = vec![0];
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    async fn consume_backup_code(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+        code_hash: &[u8],
+    ) -> Result<bool, DbError> {
+        let mut codes = self.codes.lock().await;
+        if let Some(c) = codes.iter_mut().find(|(a, u, h, used)| {
+            *a == account_id && u == user_id && h.as_slice() == code_hash && used.is_none()
+        }) {
+            c.3 = Some(Utc::now());
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    async fn unused_backup_codes_count(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+    ) -> Result<i64, DbError> {
+        let codes = self.codes.lock().await;
+        Ok(codes
+            .iter()
+            .filter(|(a, u, _, used)| *a == account_id && u == user_id && used.is_none())
+            .count() as i64)
+    }
+
+    async fn replace_backup_codes(
+        &self,
+        account_id: Uuid,
+        user_id: &str,
+        new_hashes: &[Vec<u8>],
+    ) -> Result<(), DbError> {
+        let mut codes = self.codes.lock().await;
+        codes.retain(|(a, u, _, _)| !(*a == account_id && u == user_id));
+        for h in new_hashes {
+            codes.push((account_id, user_id.to_string(), h.clone(), None));
+        }
+        Ok(())
+    }
+}
+
+fn fixture_with_totp() -> (Arc<AppState>, Arc<MemTotpRepo>) {
+    let key_hash = hex::encode(Sha256::digest(TEST_API_KEY.as_bytes()));
+    let account_id = Uuid::new_v4();
+    let key_id = Uuid::new_v4();
+    let account_repo = Arc::new(MockAccountRepo {
+        account: Account {
+            id: account_id, name: "Test".into(), owner_email: "t@t".into(),
+            is_active: true, created_at: Utc::now(), updated_at: Utc::now(),
+        },
+        api_key: ApiKey {
+            id: key_id, account_id, name: "k".into(), key_prefix: "ch_test_ab...".into(),
+            environment: "test".into(), last_used_at: None, expires_at: None,
+            is_revoked: false, created_at: Utc::now(),
+        },
+        key_hash,
+    });
+    let messages = Arc::new(MockMessageRepo::new());
+    let suppressions = Arc::new(MockSuppressionRepo::new());
+    let api_key_repo = Arc::new(MockApiKeyRepo);
+    let provider_config_repo = Arc::new(MockProviderConfigRepo);
+    let webhook_repo = Arc::new(MockWebhookRepo);
+    let idempotency_repo: Arc<dyn IdempotencyRepository> = Arc::new(MemIdempotencyRepo::new());
+    let verification_repo: Arc<dyn VerificationRepository> = Arc::new(NullVerificationRepo);
+    let totp_repo: Arc<MemTotpRepo> = Arc::new(MemTotpRepo::new());
+    let totp_dyn: Arc<dyn TotpRepository> = totp_repo.clone();
+    let encryptor = null_encryptor();
+    let redis = redis::Client::open("redis://127.0.0.1:6379").unwrap();
+    let config = Arc::new(Config::from_env());
+    let state = Arc::new(AppState::with_repos(
+        redis, config, account_repo, messages, api_key_repo,
+        provider_config_repo, webhook_repo, suppressions,
+        idempotency_repo, verification_repo, totp_dyn, encryptor,
+    ));
+    (state, totp_repo)
+}
+
+#[tokio::test]
+#[ignore = "requires Valkey/Redis on localhost:6379"]
+async fn enroll_returns_qr_and_pending_status() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let body = serde_json::json!({"user_id":"alice@app.com","issuer":"Acme"}).to_string();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let v = response_body(resp).await;
+    assert_eq!(v["user_id"], "alice@app.com");
+    assert_eq!(v["status"], "pending");
+    assert!(v["otpauth_uri"].as_str().unwrap().starts_with("otpauth://totp/"));
+    assert!(v["qr_code_png"].as_str().unwrap().starts_with("data:image/png;base64,"));
+    assert_eq!(v["backup_codes"].as_array().unwrap().len(), 10);
+    assert_eq!(v["cost_micro"], 0);
+}
+
+#[tokio::test]
+async fn enroll_returns_400_when_user_id_empty() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST").uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(r#"{"user_id":""}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response_body(resp).await["error"]["code"], "invalid_user_id");
+}
+
+#[tokio::test]
+async fn enroll_returns_400_when_user_id_too_long() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let long = "a".repeat(256);
+    let body = serde_json::json!({"user_id": long}).to_string();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST").uri("/v1/totp/enroll")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ignore = "requires Valkey/Redis on localhost:6379"]
+async fn enroll_returns_409_when_user_already_enrolled() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let body = serde_json::json!({"user_id":"alice"}).to_string();
+    let _ = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body.clone())).unwrap()
+    ).await.unwrap();
+
+    let resp = app.oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body)).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    assert_eq!(response_body(resp).await["error"]["code"], "already_enrolled");
+}
+
+#[tokio::test]
+#[ignore = "requires Valkey/Redis on localhost:6379"]
+async fn enroll_idempotency_replay_is_identical() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let key = "enroll-key-1";
+    let body = serde_json::json!({"user_id":"bob"}).to_string();
+
+    let resp1 = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("Idempotency-Key", key)
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body.clone())).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp1.status(), StatusCode::CREATED);
+    let bytes1 = resp1.into_body().collect().await.unwrap().to_bytes();
+
+    let resp2 = app.oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("Idempotency-Key", key)
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body)).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp2.status(), StatusCode::CREATED);
+    let bytes2 = resp2.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(bytes1, bytes2);
+}
+
+#[tokio::test]
+async fn activate_returns_404_when_unknown_user() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let body = serde_json::json!({"user_id":"ghost","code":"123456"}).to_string();
+    let resp = app
+        .oneshot(
+            Request::builder().method("POST").uri("/v1/totp/activate")
+                .header("authorization", format!("Bearer {TEST_API_KEY}"))
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body)).unwrap(),
+        )
+        .await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+#[ignore = "requires Valkey/Redis on localhost:6379"]
+async fn disenroll_active_user_succeeds_and_second_call_returns_410() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let body = serde_json::json!({"user_id":"alice"}).to_string();
+    let _ = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body)).unwrap()
+    ).await.unwrap();
+
+    let resp = app.clone().oneshot(
+        Request::builder().method("DELETE").uri("/v1/totp/alice")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .body(axum::body::Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = app.oneshot(
+        Request::builder().method("DELETE").uri("/v1/totp/alice")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .body(axum::body::Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::GONE);
+}
+
+#[tokio::test]
+async fn status_for_unknown_user_returns_404() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let resp = app.oneshot(
+        Request::builder().method("GET").uri("/v1/totp/ghost")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .body(axum::body::Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+#[ignore = "requires Valkey/Redis on localhost:6379"]
+async fn status_for_pending_user_returns_metadata() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    let _ = app.clone().oneshot(
+        Request::builder().method("POST").uri("/v1/totp/enroll")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(r#"{"user_id":"alice"}"#))
+            .unwrap()
+    ).await.unwrap();
+
+    let resp = app.oneshot(
+        Request::builder().method("GET").uri("/v1/totp/alice")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .body(axum::body::Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = response_body(resp).await;
+    assert_eq!(v["user_id"], "alice");
+    assert_eq!(v["status"], "pending");
+    // ensure no plaintext secret leaks
+    assert!(v.get("secret").is_none());
+}
+
+#[tokio::test]
+async fn verify_returns_404_when_unknown_user() {
+    let (state, _repo) = fixture_with_totp();
+    let app = create_router(state);
+    // No enrollment exists → find returns None → 404
+    let body = serde_json::json!({"user_id":"ghost","code":"483921"}).to_string();
+    let resp = app.oneshot(
+        Request::builder().method("POST").uri("/v1/totp/verify")
+            .header("authorization", format!("Bearer {TEST_API_KEY}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body)).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

RFC 6238 TOTP enrollment + verification at `/v1/totp/*` — **$0 per verification**
(vs Twilio Verify $0.013/check). Second deliverable of the B (differentiator) tier.

### Headline economics
| Operation | chorus | Twilio Verify | Auth0 MFA | Saving |
|---|---|---|---|---|
| TOTP enroll | **$0** | $0.05 | $0.045 | 100% |
| TOTP verify | **$0** | $0.013 | $0.012 | 100% |
| Backup-code verify | **$0** | $0.013 | $0.012 | 100% |

### What landed
- 7 endpoints: `enroll` / `activate` / `verify` / `disenroll` / `status` / `backup-codes/regenerate` / `GET /qr`
- **First introduction of end-user identity concept to chorus** — opaque `user_id` string (1-255 ASCII printable)
- RFC 6238 defaults: SHA1 / 6 digits / 30s period / ±1 step window
- 2-step enrollment (enroll → pending → activate → active) — prevents lockout on bad QR scan
- 10 one-use backup recovery codes (10-char `[a-z0-9]{4}-[a-z0-9]{5}`); SHA-256 at rest; regenerate endpoint
- **AES-GCM-256 secret encryption at rest** via new `crypto.rs` module (env `CHORUS_ENCRYPTION_KEY`) — first encrypted column in chorus
- Single shared secret per user (multi-device = scan same QR on N devices)
- Reuses B1 Lua sliding-window rate limits: per-user 5/min verify, 10/min activate, 10/min enroll; per-account 100/min
- Idempotency-Key on `enroll` + `regenerate` (reuses C1)
- `cost_micro: 0` everywhere (hero pitch)
- 7 Prometheus metrics

### Spec & plan
- Spec: `docs/superpowers/specs/2026-05-19-totp-design.md`
- Plan: `docs/superpowers/plans/2026-05-19-totp.md`

## Pre-merge verification (all 6 reviewer items completed)

- [x] **Code review of `crypto.rs`** (AES-GCM blob layout, fail-fast key loading)
  - Blob layout `nonce(12) || ciphertext || tag(16)` matches spec §3
  - `from_env` fails fast on 3 distinct conditions: missing var, malformed base64, wrong length — each with clear error message
  - `Aes256Gcm::generate_nonce` uses `OsRng` (CSPRNG)
  - Length guard `blob.len() < NONCE_LEN + TAG_LEN` prevents OOB on too-short input
  - 9 unit tests cover round-trip (3 sizes), short-blob rejection, tampered-ciphertext (GCM tag) rejection, wrong-key rejection, nonce uniqueness (100 same-plaintext → 100 unique blobs), `from_env` failure modes (3)
- [x] **Code review of TOTP RFC 6238 implementation**
  - `compute_totp` delegates to `totp_lite::totp_custom::<Sha1>(period=30, digits=6, secret, time)` — well-tested library
  - `verify_totp_with_window` iterates `-1..=+1` step offsets (3 candidate codes), short-circuits on first match, has underflow guard (`candidate_step < 0`)
  - 3 RFC 6238 §B test vectors verified: t=59→`287082`, t=1111111109→`081804`, t=1234567890→`005924` (6-digit truncation of 8-digit `89005924`)
  - Non-constant-time `String ==` comparison noted as a theoretical timing leak; **mitigated** by the 5/min rate limit (attacker cannot make enough measurements to extract a digit); practical risk = 0
- [x] **Code review of routes pattern** (Bytes + idempotency, no secret serialization)
  - `enroll_totp` + `regenerate_backup_codes` use `Bytes` body + `idempotency::begin/finalize_and_respond` — matches B1 pattern
  - `activate_totp` + `verify_totp` use `Json<T>` (no idempotency) — intentional per spec Q9a (natural idempotency via status guards)
  - `TotpUser.secret` field has `#[serde(skip)]` (db/mod.rs:482) — never echoed back to clients
  - All response paths use `TotpUserPublic::from(user, unused)` projection or dedicated response structs (`EnrollResponse`, `RegenerateResponse`, `VerifyResponse`) — secret never leaks
  - Plaintext backup codes returned only in `EnrollResponse` and `RegenerateResponse` (user must save) — never echoed on verify
  - Secret is decrypted via `encryptor().decrypt(&user.secret)` only inside verify/activate paths, then passed to `verify_totp_with_window` — not echoed
- [x] **Smoke environment + all 8 curl scenarios** (run against fresh `postgres:16-alpine` + `valkey/valkey:8-alpine` with random `CHORUS_ENCRYPTION_KEY`):
  - **Scenario 1:** Enroll → 201, `status:"pending"`, 10 backup codes, `cost_micro:0`, `qr_code_png` valid data URI ✓
  - **Scenario 2:** Activate (computed code from extracted secret) → HTTP 200, `status:"active"`, `activated_at` set ✓
  - **Scenario 3:** Verify with fresh TOTP code → HTTP 200, `verified:true`, `method:"totp"` ✓
  - **Scenario 4:** Verify with backup code → HTTP 200, `verified:true`, `method:"backup_code"` ✓
  - **Scenario 5:** Replay same backup code → HTTP 422 `incorrect_code` (one-use enforced) ✓
  - **Scenario 6:** Rate-limit loop 8 wrong codes → `[422, 422, 429, 429, 429, 429, 429, 429]` (5/min/user budget exhausted after the 4 successful verifies in scenarios 2-4 + 1 wrong replay; first 2 of loop fit in remaining budget, then 6× 429) ✓
  - **Scenario 7:** Postgres state — `octet_length(secret) = 48` (encrypted blob ≠ 20-byte plaintext); 10 backup codes total + 1 used ✓
  - **Scenario 8:** `/metrics` exposes all 7 instruments correctly (counters + gauge + histograms) ✓
- [x] **Repo tests against real PG** — `DATABASE_URL=postgres://chorus:chorus@localhost:5433/chorus cargo test --lib db::totp:: -- --ignored --test-threads=1` → **12/12 passed**:
  - `activate_errors_when_not_pending`, `activate_pending_to_active`, `cascade_delete_on_account_removal_drops_user_and_codes`, `consume_backup_code_marks_used_and_returns_true`, `consume_backup_code_returns_false_when_unknown`, `disenroll_clears_secret`, `enroll_creates_pending_user_with_backup_codes`, `enroll_errors_when_user_already_active`, `find_returns_none_for_unknown`, `find_scopes_to_account`, `replace_backup_codes_atomically_swaps`, `unused_backup_codes_count_excludes_used`
- [x] **Inspect `/metrics`** — `chorus_totp_*` counters confirmed emitting:
  ```
  chorus_totp_enrollments_total{outcome="created"} 1
  chorus_totp_verifies_total{outcome="approved",method="totp"} 1
  chorus_totp_verifies_total{outcome="approved",method="backup_code"} 1
  chorus_totp_verifies_total{outcome="wrong_code",method="totp"} 2
  chorus_totp_verifies_total{outcome="wrong_code",method="backup_code"} 1
  chorus_totp_backup_codes_remaining 9
  chorus_totp_enroll_duration_seconds (histogram, 1 sample)
  chorus_totp_verify_duration_seconds (histogram, 11 samples)
  ```

## Automated checks (run by CI)
- 9 `crypto::tests` unit tests (round-trip, tamper-rejection, env-var validation)
- 28 `totp::tests` unit tests (RFC 6238 vectors, ±1 window, base32, otpauth URI, backup codes, QR, user_id validator)
- 12 sqlx repo tests — `#[ignore]` by default; run with `-- --ignored` + `DATABASE_URL` (verified above)
- 57 api_test cases passing + 16 `#[ignore]`d for Valkey-dependent paths
- README documents `CHORUS_ENCRYPTION_KEY` env var + dev key generation

## Smoke reproduction recipe

```bash
podman run -d --name chorus-totp-pg -e POSTGRES_USER=chorus -e POSTGRES_PASSWORD=chorus \
  -e POSTGRES_DB=chorus -p 5433:5432 postgres:16-alpine
podman run -d --name chorus-totp-vk -p 6380:6379 docker.io/valkey/valkey:8-alpine

KEY=$(head -c 32 /dev/urandom | base64)
DATABASE_URL=postgres://chorus:chorus@localhost:5433/chorus \
  REDIS_URL=redis://127.0.0.1:6380 PORT=3001 HOST=127.0.0.1 \
  CHORUS_ENCRYPTION_KEY="$KEY" \
  cargo run -p chorus-server &

# seed account+api_key via SQL (see plan §T15 Step 3)
# then run the 8 curl scenarios above

DATABASE_URL=postgres://chorus:chorus@localhost:5433/chorus \
  cargo test --lib db::totp:: -- --ignored --test-threads=1
```